### PR TITLE
Add -A/--advance argument to advance initiative-based jobs by N rounds

### DIFF
--- a/cron/Help.txt
+++ b/cron/Help.txt
@@ -66,6 +66,11 @@ The "cron" command accepts the following options:
     -f USER, --from USER	The command will be executed as USER.  This need
 				not be a player or character in the game.
 
+    -A N, --advance N		Advance the round counter by N rounds.  This
+				will cause initiative-based jobs to advance as
+				if the tracker had been advanced through N full
+				rounds.
+
     -l, --list			List all scheduled jobs.
 
     -R, --remove		Remove all specified jobs.  All other arguments

--- a/cron/cron.js
+++ b/cron/cron.js
@@ -68,13 +68,15 @@ var cron = cron || {
 	}
     },
 
-    handleTurnChange: function(newTurnOrder, oldTurnOrder){
+    handleTurnChange: function(newTurnOrder, oldTurnOrder, force){
 	var newTurns = JSON.parse((typeof(newTurnOrder) == typeof("") ? newTurnOrder : newTurnOrder.get('turnorder') || "[]"));
 	var oldTurns = JSON.parse((typeof(oldTurnOrder) == typeof("") ? oldTurnOrder : oldTurnOrder.turnorder || "[]"));
 
-	if ((!newTurns) || (!oldTurns)){ return; }
-	if ((!newTurns.length) || (newTurns.length != oldTurns.length)){ return; } // something was added or removed; ignore
-	if ((newTurns[0].id == oldTurns[0].id) && ((newTurns.length != 1) || (newTurns[0].pr != oldTurns[0].pr))){ return; } // turn didn't change
+	if (!force){
+	    if ((!newTurns) || (!oldTurns)){ return; }
+	    if ((!newTurns.length) || (newTurns.length != oldTurns.length)){ return; } // something was added or removed; ignore
+	    if ((newTurns[0].id == oldTurns[0].id) && ((newTurns.length != 1) || (newTurns[0].pr != oldTurns[0].pr))){ return; } // turn didn't change
+	}
 
 	var newCount = newTurns[0].pr;
 	var oldCount = oldTurns[0].pr;
@@ -129,7 +131,23 @@ var cron = cron || {
 	    }
 	}
 	jobsToFire.sort();
-	if (newCount < oldCount){ jobsToFire.reverse(); }
+	if (highToLow){ jobsToFire.reverse(); }
+	if (wrapped){
+	    // wrapped, so some may be below lowest count, others above highest count; sort appropriately
+	    var cutIdx = 0;
+	    while (cutIdx < jobsToFire.length){
+		if ((highToLow) && (jobsToFire[cutIdx][0] < newCount)){ break; }
+		if ((!highToLow) && (jobsToFire[cutIdx][0] > newCount)){ break; }
+		cutIdx += 1;
+	    }
+	    if ((cutIdx > 0) && (cutIdx < jobsToFire.length)){
+		// move first cutIdx elements of jobsToFire to end
+		var cutChunk = jobsToFire.splice(0, cutIdx);
+		cutChunk.unshift(0);
+		cutChunk.unshift(jobsToFire.length);
+		jobsToFire.splice.apply(jobsToFire, cutChunk);
+	    }
+	}
 	for (var i = 0; i < jobsToFire.length; i++){
 	    cron.handleJob(state.cron.countJobs[jobsToFire[i][1]]);
 	}
@@ -305,11 +323,13 @@ var cron = cron || {
     showHelp: function(who, cmd){
 	var helpMsg = "";
 	helpMsg += "Usage: " + cmd + " [options] command\n";
+	helpMsg += "  or:  " + cmd + " -A n\n";
 	helpMsg += "  or:  " + cmd + " -l\n";
 	helpMsg += "  or:  " + cmd + " -R job_IDs\n";
 	helpMsg += "In the first form, the specified command is scheduled to be run later.\n";
-	helpMsg += "In the second form, all scheduled jobs are listed.\n";
-	helpMsg += "In the third form, one or more scheduled jobs are removed.\n";
+	helpMsg += "In the second form, the round counter is advanced n rounds, executing jobs as necessary.\n";
+	helpMsg += "In the third form, all scheduled jobs are listed.\n";
+	helpMsg += "In the fourth form, one or more scheduled jobs are removed.\n";
 	cron.write(helpMsg, who, "", "CronD");
 	helpMsg = "Options:\n";
 	helpMsg += "  -h, --help:               display this help message\n";
@@ -320,6 +340,7 @@ var cron = cron || {
 	helpMsg += "  -i I, --interval I        repeat command every I rounds or time (HH:MM:SS)\n";
 	helpMsg += "  -n N, --runs N            remove repeating job after N executions\n";
 	helpMsg += "  -f USER, --from USER      execute command as specified user\n";
+	helpMsg += "  -A N, --advance N         advance time by N rounds, executing jobs as necessary\n";
 	helpMsg += "  -l, --list                list all scheduled jobs\n";
 	helpMsg += "  -R, --remove              remove all specified jobs (separate IDs with spaces)\n";
 	cron.write(helpMsg, who, "font-size: small; font-family: monospace", "CronD");
@@ -352,6 +373,7 @@ var cron = cron || {
 	    args['from'] = "player|" + msg.playerid;
 	}
 	var getArg = null;
+	var doAdvance = false;
 	var doList = false;
 	var doRemove = false;
 	var cmdArray = [];
@@ -390,6 +412,11 @@ var cron = cron || {
 	    case "--from":
 		getArg = 'from';
 		break;
+	    case "-A":
+	    case "--advance":
+		getArg = 'advance';
+		doAdvance = true;
+		break;
 	    case "-l":
 	    case "--list":
 		doList = true;
@@ -404,6 +431,20 @@ var cron = cron || {
 	    default:
 		cmdArray.push(tokens[i]);
 	    }
+	}
+
+	if (doAdvance){
+	    // advance initiative-based jobs by args['advance'] rounds
+	    var advanceCount = parseInt(args['advance']);
+	    if (!(advanceCount > 0)){ // "!>0" rather than "<=0" to account for NaN
+		cron.write("Error: Invalid number of rounds to advance: " + args['advance'], msg.who, "", "CronD");
+		return;
+	    }
+	    var turnOrder = Campaign().get('turnorder') || "[]";
+	    for (var i = 0; i < advanceCount; i++){
+		cron.handleTurnChange(turnOrder, turnOrder, true);
+	    }
+	    return;
 	}
 
 	if (doList){

--- a/cron/cron.js
+++ b/cron/cron.js
@@ -8,6 +8,7 @@ var cron = cron || {
 
 	// set timers for existing timed jobs
 	for (var jobId in state.cron.timedJobs){
+	    if (!state.cron.timedJobs.hasOwnProperty(jobId)){ continue; }
 	    var job = state.cron.timedJobs[jobId];
 	    var handlerFunc = function(){ cron.handleTimedJob(jobId); }
 	    var fireDate = new Date(job['timestamp']);
@@ -73,20 +74,47 @@ var cron = cron || {
 
 	if ((!newTurns) || (!oldTurns)){ return; }
 	if ((!newTurns.length) || (newTurns.length != oldTurns.length)){ return; } // something was added or removed; ignore
-	if (newTurns[0].id == oldTurns[0].id){ return; } // turn didn't change
+	if ((newTurns[0].id == oldTurns[0].id) && ((newTurns.length != 1) || (newTurns[0].pr != oldTurns[0].pr))){ return; } // turn didn't change
 
 	var newCount = newTurns[0].pr;
 	var oldCount = oldTurns[0].pr;
 
-	if (newCount == oldCount){ return; } // initiative count didn't change
+	if ((newCount == oldCount) && (newTurns[0].id != oldTurns[0].id)){ return; } // initiative count didn't change
+
+	// determine if initiative order is high-to-low or low-to-high
+	var highToLow = true;
+	if (newTurns.length > 2){
+	    var highIdx = 0;
+	    for (var i = 1; i < newTurns.length; i++){
+		if (newTurns[i].pr > newTurns[highIdx].pr){
+		    if (highIdx == 0){
+			highIdx = i;
+		    }
+		    else{
+			highToLow = false;
+			break;
+		    }
+		}
+	    }
+	}
+	var wrapped = ((newCount > oldCount) == highToLow) || (newTurns.length == 1);
 
 	var jobsToFire = [];
 	var jobsToDelete = [];
 	for (var i in state.cron.countJobs){
+	    if (!state.cron.countJobs.hasOwnProperty(i)){ continue; }
 	    var job = state.cron.countJobs[i];
-	    if ((job.count >= oldCount) && (job.count > newCount)){ continue; } // greater than oldCount and newCount, so not between them; ignore job
-	    if ((job.count <= oldCount) && (job.count < newCount)){ continue; } // less than oldCount and newCount, so not between them; ignore job
-	    // if we got here, then job is between oldCount and newCount (possibly equal to newCount); fire event or decrement rounds until firing
+	    if (wrapped){
+		// we wrapped around; ignore jobs between oldCount and newCount
+		if ((job.count >= oldCount) && (job.count < newCount)){ continue; } // greater than oldCount and less than newCount, so between them
+		if ((job.count <= oldCount) && (job.count > newCount)){ continue; } // less than oldCount and greater than newCount, so between them
+	    }
+	    else{
+		// we advanced without wrapping; ignore jobs not between oldCount and newCount
+		if ((job.count >= oldCount) && (job.count > newCount)){ continue; } // greater than oldCount and newCount, so not between them
+		if ((job.count <= oldCount) && (job.count < newCount)){ continue; } // less than oldCount and newCount, so not between them
+	    }
+	    // if we got here, then job's count has either come up or just been passed over; fire event or decrement rounds until firing
 	    if (job.rounds > 0){ job.rounds -= 1; }
 	    if (job.rounds == 0){
 		jobsToFire.push([job.count, i]);
@@ -217,8 +245,12 @@ var cron = cron || {
 	var countIds = [];
 	var timedIds = [];
 
-	for (var jobId in state.cron.countJobs){ countIds.push(jobId); }
-	for (var jobId in state.cron.timedJobs){ timedIds.push(jobId); }
+	for (var jobId in state.cron.countJobs){
+	    if (state.cron.countJobs.hasOwnProperty(jobId)){ countIds.push(jobId); }
+	}
+	for (var jobId in state.cron.timedJobs){
+	    if (state.cron.timedJobs.hasOwnProperty(jobId)){ timedIds.push(jobId); }
+	}
 	countIds.sort();
 	timedIds.sort();
 

--- a/cron/package.json
+++ b/cron/package.json
@@ -1,6 +1,6 @@
 {
     "name":		"cron",
-    "version":		"0.9",
+    "version":		"0.10",
     "description":	"Schedule (possibly recurring) commands to run at some point in the future.",
     "authors":		"manveti",
     "roll20userid":	"503018",


### PR DESCRIPTION
Also improve support for jobs on counts outside the range present in the tracker (e.g. tracker contains entries on counts 10, 5, and 3, and a cron job is scheduled to go off on count 0).