### PR TITLE
Fixed same-map bug in 'Its A Trap' script AND new World Map Discovery script.

### DIFF
--- a/Its A Trap/ItsATrap.js
+++ b/Its A Trap/ItsATrap.js
@@ -1,21 +1,21 @@
 /**
  * A script that checks the interpolation of a token's movement to detect
  * whether they have passed through a square containing a trap.
- * 
- * A trap can be any token on the GM layer for which the cobweb status is 
- * active. Flying tokens (ones with the fluffy-wing status or angel-outfit 
+ *
+ * A trap can be any token on the GM layer for which the cobweb status is
+ * active. Flying tokens (ones with the fluffy-wing status or angel-outfit
  * status active) will not set off traps unless the traps are also flying.
- * 
- * This script works best for square traps equal or less than 2x2 squares or  
+ *
+ * This script works best for square traps equal or less than 2x2 squares or
  * circular traps of any size.
  */
 var ItsATrap = (function() {
-  
+
   /**
    * Returns the first trap a token collided with during its last movement.
    * If it didn't collide with any traps, return false.
    * @param {Graphic} token
-   * @return {Graphic || false} 
+   * @return {Graphic || false}
    */
   var getTrapCollision = function(token) {
       var traps = getTrapTokens();
@@ -25,19 +25,19 @@ var ItsATrap = (function() {
 
       return TokenCollisions.getFirstCollision(token, traps);
   };
-  
-  
+
+
   /**
    * Determines whether a token is currently flying.
    * @param {Graphic} token
    * @return {Boolean}
    */
   var isTokenFlying = function(token) {
-      return (token.get("status_fluffy-wing") || 
-              token.get("status_angel-outfit")); 
-  }; 
-   
-  
+      return (token.get("status_fluffy-wing") ||
+              token.get("status_angel-outfit"));
+  };
+
+
   /**
    * Moves the specified token to the same position as the trap.
    * @param {Graphic} token
@@ -46,35 +46,35 @@ var ItsATrap = (function() {
   var moveTokenToTrap = function(token, trap) {
     var x = trap.get("left");
     var y = trap.get("top");
-    
+
     token.set("lastmove","");
     token.set("left", x);
     token.set("top", y);
   };
-  
 
-  
-  
+
+
+
   /**
    * Returns all trap tokens on the players' page.
    */
   var getTrapTokens = function() {
       var currentPageId = Campaign().get("playerpageid");
-      return findObjs({_pageid: currentPageId, 
-                              _type: "graphic", 
-                              status_cobweb: true, 
+      return findObjs({_pageid: currentPageId,
+                              _type: "graphic",
+                              status_cobweb: true,
                               layer: "gmlayer"});
   };
-  
-  
-  
+
+
+
   /**
    * Filters items out from a list using some filtering function.
    * Only items for which the filtering function returns true are kept in the
    * filtered list.
    * @param {Object[]} list
-   * @param {Function} filterFunc   Accepts an Object from list as a parameter. 
-   *                                Returns true to keep the item, or false to 
+   * @param {Function} filterFunc   Accepts an Object from list as a parameter.
+   *                                Returns true to keep the item, or false to
    *                                discard.
    * @return {Object[]}
    */
@@ -88,23 +88,34 @@ var ItsATrap = (function() {
       }
       return results;
   }
-  
-  
-  /** 
+
+
+  /**
    * When a graphic on the objects layer moves, run the script to see if it
    * passed through any traps.
    */
   on("change:graphic", function(obj, prev) {
-      
+      var activePage = Campaign().get('playerpageid');
+
       // Objects on the GM layer don't set off traps.
-      if(obj.get("layer") === "objects") {
+      if(obj.get("layer") === "objects" && obj.get('_pageid') == activePage) {
+        //  log('last move for ' + obj.get('name') + ':');
+        //  log(obj.get('lastmove'));
+
           var trap = getTrapCollision(obj);
-          
+
           if(trap) {
-              sendChat("Admiral Ackbar", "IT'S A TRAP!!! " + obj.get("name") + " set off a trap!");
-              
+              var trapName = trap.get("name");
+              if(trapName) {
+                sendChat("Admiral Ackbar", "IT'S A TRAP!!! " + obj.get("name") + " set off a trap: " + trapName + "!");
+              }
+              else {
+                sendChat("Admiral Ackbar", "IT'S A TRAP!!! " + obj.get("name") + " set off a trap!");
+              }
+
+
               moveTokenToTrap(obj, trap);
-              
+
               if(trap.get("status_bleeding-eye")) {
                   trap.set("layer","objects");
                   toBack(trap);

--- a/WorldMapDiscovery/README.md
+++ b/WorldMapDiscovery/README.md
@@ -1,0 +1,20 @@
+# World Map Discovery
+
+###### Required Scripts
+* [Vector Math](https://github.com/Roll20/roll20-api-scripts/tree/master/Vector%20Math)
+
+This script allows the GM to set hidden locations on a world map that can be
+revealed when a character gets close enough.
+
+### To use:
+
+1) Turn on the landmark's white-tower status (The one that looks like a tower).
+2) Set the landmark's aura 1 radius to whatever radius you want players to come within to discover the landmark.
+3) Put the landmark on the GM layer.
+
+### Discovering landmarks:
+
+When a character token moves within the aura radius of the landmark, the landmark 
+will appear on the graphics layer and a message will be displayed
+telling everyone that the character discovered it. When the landmark is
+discovered, its aura1 radius is removed.

--- a/WorldMapDiscovery/WorldMapDiscovery.js
+++ b/WorldMapDiscovery/WorldMapDiscovery.js
@@ -1,0 +1,132 @@
+/**
+ * This script allows the GM to set hidden locations on a world map that can be
+ * revealed when a character gets close enough.
+ *
+ * To use:
+ * 1) Turn on the landmark's white-tower status (The one that looks like a tower).
+ * 2) Set the landmark's aura 1 radius to whatever radius you want players to come
+ * within to discover the landmark.
+ * 3) Put the landmark on the GM layer.
+ *
+ * When a character token moves within the aura radius of the landmark, the
+ * landmark will appear on the graphics layer and a message will be displayed
+ * telling everyone that the character discovered it. When the landmark is
+ * discovered, its aura1 radius is removed.
+ *
+ * Depends on:
+ *    VecMath
+ */
+var WorldMapDiscovery = (function() {
+
+    var PIXELS_PER_SQUARE = 70;
+
+    /**
+     * Returns the first undiscovered location the token is in range of, or null
+     * if the token is not in range of an undiscvered location.
+     * @param {Graphic} token
+     * @return {Graphic}
+     */
+    var getLocationCollision = function(token) {
+        var allLocations = getLocationTokens();
+        var tokenPt = getTokenPt(token);
+
+        var result = _.find(allLocations, function(location) {
+            var locationPt = getTokenPt(location);
+            var dist = VecMath.dist(tokenPt, locationPt);
+            var threshold = getDiscoveryDistance(location);
+            return (dist <= threshold);
+        });
+        return result;
+    };
+
+    /**
+     * Returns all location tokens on the players' page.
+     * Undiscovered locations reside on the gm layer.
+     * @return {Graphic[]}
+     */
+    var getLocationTokens = function() {
+        var currentPageId = Campaign().get("playerpageid");
+        return findObjs({_pageid: currentPageId,
+                                _type: "graphic",
+                                'status_white-tower': true,
+                                layer: "gmlayer"});
+    };
+
+
+    /**
+     * Gets the location of a token as a point.
+     * @param {Graphic}
+     * @return {vec2}
+     */
+    var getTokenPt = function(token) {
+        var x = token.get("left");
+        var y = token.get("top");
+        return [x, y];
+    };
+
+
+    /**
+     * Causes a location to become discovered.
+     * @param {Graphic} location      The location that is being discovered.
+     * @param {Graphic} discoverer    The token that discovered the location.
+     */
+    var discoverLocation = function(location, discoverer) {
+    //    log('WorldMapDiscover DEBUG ');
+    //    log(getDiscoveryDistance(location));
+        var tokenPt = getTokenPt(discoverer);
+    //    log('Discoverer: ');
+    //    log(discoverer);
+    //    log(tokenPt);
+        var locationPt = getTokenPt(location);
+    //    log('Location: ');
+    //    log(location);
+    //    log(locationPt);
+        var dist = VecMath.dist(tokenPt, locationPt);
+    //    log(dist);
+
+        location.set('layer', 'objects');
+        location.set('aura1_radius', '');
+        toBack(location);
+
+        sendChat('MAP', discoverer.get('name') + " has discovered " + location.get('name') + ".");
+    };
+
+
+    /**
+     * Gets the discovery distance for a location based on its aura's radius.
+     */
+    var getDiscoveryDistance = function(location) {
+        var radiusUnits = location.get('aura1_radius');
+
+        var currentPageId = Campaign().get("playerpageid");
+        var page = findObjs({_id: currentPageId, _type: "page"})[0];
+        var pageScale = page.get('scale_number');
+
+        return radiusUnits/pageScale*PIXELS_PER_SQUARE + location.get('width')/2;
+    };
+
+
+    /**
+     * When a graphic on the objects layer moves, run the script to see if it
+     * passed through any traps.
+     */
+    on("change:graphic", function(obj, prev) {
+        var activePage = Campaign().get('playerpageid');
+
+        if(obj && obj.get('status_white-tower') == true) {
+            var locationPt = getTokenPt(obj);
+        //    log('Location: ');
+        //    log(obj);
+        //    log(locationPt);
+        }
+
+        // Objects on the GM layer don't set off traps.
+        if(obj.get("layer") === "objects" && obj.get("represents") && obj.get('_pageid') == activePage) {
+            var location = getLocationCollision(obj);
+
+            if(location) {
+                discoverLocation(location, obj);
+            }
+        }
+    });
+})();

--- a/WorldMapDiscovery/package.json
+++ b/WorldMapDiscovery/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "World Map Discovery",
+    "version": "1.0",
+    "description": "Set up dynamic landmarks on the map which can be discovered by the players.",
+    "authors": "Stephen Lindberg",
+    "roll20userid": 46544,
+    "dependencies": {
+        "Token Collisions": "1.1",
+        "Vector Math": "1.0"
+    },
+    "modifies": {
+        "aura1_radius": "read, write",
+        "chat": "write",
+        "lastmove": "write",
+        "layer": "read, write",
+        "left": "read, write",
+        "status_white-tower": "read",
+        "token": "read",
+        "top": "read, write"
+    },
+    "conflicts": []
+}


### PR DESCRIPTION
There was a bug involving tokens representing characters which caused the script to get the wrong character coordinates for detecting collisions with traps. 

Whenever a character token's status bar changed, it would fire a change event for every instance for that character's token on every map they're present on. This was causing the script to sometimes try a collision between the character on another map and with a trap on the current map whenever the tokens' status bars change. 

This was fixed by restricting the script to only check collisions for character tokens on the players' current page.