### PR TITLE
TurnLock

### DIFF
--- a/TurnLock/Help.txt
+++ b/TurnLock/Help.txt
@@ -1,0 +1,4 @@
+Commands:
+
+!tlock (enables turn lock, preventing tokens from moving if it is not their turn)
+!tunlock (disables turn lock)

--- a/TurnLock/TurnLock.js
+++ b/TurnLock/TurnLock.js
@@ -1,4 +1,4 @@
-// Github:   https://github.com/anthonytasca/roll20-api-scripts/turnlock
+// Github:   https://github.com/anthonytasca/roll20-api-scripts/blob/master/TurnLock/TurnLock.js
 // By:       Anthony Tasca
 // Contact:  https://app.roll20.net/users/1000007/target
 

--- a/TurnLock/TurnLock.js
+++ b/TurnLock/TurnLock.js
@@ -1,0 +1,54 @@
+// Github:   https://github.com/anthonytasca/roll20-api-scripts/turnlock
+// By:       Anthony Tasca
+// Contact:  https://app.roll20.net/users/1000007/target
+
+var TurnLock = TurnLock || (function(){
+    'use strict';
+	var tlocked = false;
+	
+	function handleChat(msg) {
+		if (msg.type !== "api" || !playerIsGM(msg.playerid) ) {
+			return;
+		}
+		if(msg.content == "!tlock"){
+			tlocked = true;
+		}else if(msg.content == "!tunlock"){
+			tlocked = false;
+		}
+	};
+	
+	function handleMove(obj, prev) {
+		if(tlocked && 'token' === obj.get('subtype')){
+			var turnOrder = tOrder.Get();
+            var current = _.first(turnOrder);
+			if( obj && current && current.id === obj.id ){
+				return;
+			}else{
+				obj.set({left: prev.left, top: prev.top, rotation: prev.rotation});
+			}
+		}
+	};
+	
+	function registerEventHandlers() {
+		on('chat:message', handleChat);
+		on('change:graphic', handleMove);
+	};
+
+	return {
+		RegisterEventHandlers: registerEventHandlers
+	};
+	
+}());
+
+on("ready",function(){
+	'use strict';
+	TurnLock.RegisterEventHandlers();
+});
+
+var tOrder = tOrder || {
+    Get: function(){
+        var to=Campaign().get("turnorder");
+        to=(''===to ? '[]' : to); 
+        return JSON.parse(to);
+    },
+}

--- a/TurnLock/package.json
+++ b/TurnLock/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "TurnLock",
+    "version": "1.0.0",
+    "description": "Allows controll of whether or not tokens can move when it is not their turn",
+    "authors": "Anthony Tasca",
+    "roll20userid": "1000007",
+    "dependencies": [],
+    "modifies": {
+        "TurnLock": "read,write",
+        "campaign.turnorder": "read",
+        "graphic.left": "read,write",
+        "graphic.rotation": "read,write",
+        "graphic.top": "read,write"
+    },
+    "conflicts": []
+}


### PR DESCRIPTION
This script implements 2 GM-only api commands "!tlock" and "!tunlock" which disable
and enable the ability for tokens to move when it is not their turn. This is my first Roll20 API script so please let me know if there is work to be done!