### PR TITLE
Ryuutama Skill Check Totaler

### DIFF
--- a/Ryuutama Skill Check Totaler/package.json
+++ b/Ryuutama Skill Check Totaler/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "Ryuutama Skill Check Totaler",
+  "version": "1.0",
+  "description": "A script to automatically total the results of checks. The ability to total checks in the character sheet is nonexistent because of how critical hits have to be calculated.",
+  "authors": "King Puff",
+  "roll20userid": "665159",
+  "dependencies": "Ryuutama Character Sheet (https://github.com/Roll20/roll20-character-sheets/tree/master/Ryuutama)",
+  "modifies": [
+    "message: read",
+    "message: write"
+  ],
+  "conflicts": ""
+}

--- a/Ryuutama Skill Check Totaler/ryuutama-check-totaler.js
+++ b/Ryuutama Skill Check Totaler/ryuutama-check-totaler.js
@@ -1,0 +1,9 @@
+on("chat:message", function(msg) {
+    if (msg.type == "general" && msg.rolltemplate == 'skillCheck' || msg.rolltemplate == 'accuracyCheck') {
+        var total = 0;
+        _.each(msg.inlinerolls, function(roll) {
+            total += roll.results.total;
+        });
+        sendChat(msg.who, "<span style='font-weight:bold;font-size:1.1em;'>Total: <span style='background-color:#FEF68E;border:2px solid #FEF68E;padding:0 3px 0 3px;'>" + total + "</span></span>");
+    }
+});


### PR DESCRIPTION
Adding script to automatically total Ryuutama skill checks made with the Ryuutama character sheet since that ability cannot be done on the character sheet itself due to how critical successes are calculated.