### PR TITLE
Fix unable to find resource

### DIFF
--- a/5th Edition OGL by Roll20 Companion/1.0/5th Edition OGL by Roll20 Companion.js
+++ b/5th Edition OGL by Roll20 Companion/1.0/5th Edition OGL by Roll20 Companion.js
@@ -323,7 +323,7 @@ var handleammo = function (msg,character,player) {
         // UNABLE TO FIND AMMO
         return;
     }
-    var ammofull = msg.content.split("ammo=")[1].split(" charname")[0];
+    var ammofull = msg.content.split("ammo=")[1].split(" {{charname")[0];
     var ammoid = "";
     var ammoname = "";
     if(ammofull.substring(0,1) === "-") {


### PR DESCRIPTION
It seems that the sheet now gives the charname encapsulated in {{}} which is causing the script to not be able to find the resources, e.g. ammofull was calculated to be "Bolts {{charname=Mark's Character}}" instead of "Bolts"