### PR TITLE
Macro bug

### DIFF
--- a/Numenera_Natha/4.8/Numenera_Natha.js
+++ b/Numenera_Natha/4.8/Numenera_Natha.js
@@ -654,6 +654,7 @@ var NathaNumenera = NathaNumenera || (function () {
 	    };
 
 	    // beginning output calculation
+	skillLevel = parseInt(0 || skillLevel);	
 	    var tmplt="&{template:nathaNumRoll} {{"+attributeName+"="+attributeName+"}} {{attrEdge="+attrEdge+"}} {{finalRoll="+finalRoll+"}} {{diceRoll="+diceRoll+"}} {{skilled="+ skillLevel +"}}";
 	    if (bonusToRoll>0) tmplt += " {{bonusToRoll="+bonusToRoll+"}}";
 	    var assetsUsed = parseInt(0 || assets);


### PR DESCRIPTION
Hi!

I found a bug for the macro functionality. When a stat roll is done through a macro the "Beaten diff." ends up being weird. Out by a factor of 10 on difficulties of 0. However if the character sheet api roll button is used this error doesn't happen.

After looking through things I found that the skillLevel var is never parsed as an int inside of the statRoll function. Added a parseInt before it's used and the error no longer happens from the macro.

Cheers,

Rene