### PR TITLE
Rollable table macros

### DIFF
--- a/RollableTableMacros/1.0/RollableTableMacros.js
+++ b/RollableTableMacros/1.0/RollableTableMacros.js
@@ -1,0 +1,108 @@
+// Rollable Table Macros
+// API Commands:
+// !rtm table-name(required) myself/from-name(optional)
+
+var RollableTableMacros = RollableTableMacros || ( function() {
+    'use strict';
+    
+    var commandListener = function() {
+        // Listens for API command
+        on( 'chat:message', function( msg ) {
+            if( msg.type === 'api' && !msg.rolltemplate ) {
+                var params = msg.content.substring( 1 ).split( ' ' ),
+                    command = params[0].toLowerCase(),
+                    tableName = params[1] ? params[1].toLowerCase() : '',
+                    msgFrom = getFrom( params, msg.playerid );
+                
+                if( command === 'rtm' ) {
+                    findTable( msgFrom, tableName );
+                }
+            }
+        });
+    },
+    
+    getFrom = function( params, playerId ) {
+        // Determine the sender of the messages. Defaults to table name (formatted to title case).
+        var msgFrom = titleCase( params[1].replace( /-/g, ' ' ) );
+        
+        if( params.length > 2 ) {
+            // If the optional third paramater was passed, assign sender to that string or original sender ('myself')
+            msgFrom = params.splice( 2 ).join( ' ' );
+            msgFrom = msgFrom.toLowerCase() == 'myself' ? ( 'player|' + playerId ) : msgFrom;
+        }
+        
+        return msgFrom;
+    },
+    
+    findTable = function( msgFrom, tableName ) {
+        // Finds the corresponding table, outputs error message to chat if not found
+        var tables = findObjs({ type: 'rollabletable', name: tableName }, { caseInsensitive: true });
+        
+        if( tables.length < 1 ) {
+            sendChat( msgFrom, 'No such table exists.' );
+        } else {
+            rollTable( tables[0].id, msgFrom );
+        }
+    },
+    
+    rollTable = function( tableId, msgFrom ) {
+        // Picks an item from the table
+        var items = findObjs({ type: 'tableitem', rollabletableid: tableId }),
+            weightedList = [];
+        
+        if( items.length > 0 ) {
+            _.each( items, function( item ){
+                // Build a weighted list to draw from
+                let weight = item.get( 'weight' );
+                _( weight ).times(function( x ){
+                    weightedList.push( item.id );
+                });
+            });
+        
+            var chosenItem = getObj( 'tableitem', weightedList[ randomInteger( weightedList.length ) - 1 ] );
+        
+            sendChat( msgFrom, handleMacro( chosenItem.get( 'name' ) ) );
+        } else {
+            sendChat( msgFrom, 'No items on this table.' );
+        }
+    },
+    
+    handleMacro = function( resultText ) {
+        // Recursively handles any macro calls
+        var resultLines = resultText.split( "\n" );
+        
+        _.each( resultLines, function( line, index, resultArray ){
+            var lineArray = line.split( ' ' );
+            
+            _.each( lineArray, function( word, index, parentArray ){
+                if( word[0] === '#' ) {
+                    var macro = findObjs({ type: 'macro', name: word.substring( 1 ) });
+                
+                    parentArray[ index ] = macro.length > 0 ? handleMacro( macro[0].get( 'action' ) ) : word;
+                }
+            });
+            
+            resultArray[ index ] = lineArray.join( ' ' );
+        });
+        
+        return resultLines.join( "\n" );
+    },
+    
+    titleCase = function(str) {
+        // returns the string in title case (each word capitalized)
+        return str.toLowerCase().replace(/(^| )(\w)/g, function(x) {
+            return x.toUpperCase();
+        });
+    };
+    
+    return {
+        CommandListener: commandListener
+    };
+    
+}());
+
+on( 'ready', function(){
+   'use strict';
+   
+   RollableTableMacros.CommandListener();
+});

--- a/RollableTableMacros/RollableTableMacros.js
+++ b/RollableTableMacros/RollableTableMacros.js
@@ -1,0 +1,100 @@
+// Rollable Table Macros
+// API Commands:
+// !rtm table-name(required) myself/from-name(optional)
+
+var RollableTableMacros = RollableTableMacros || function() {
+    'use strict';
+    
+    var commandListener = function() {
+        // Listens for API command
+        on( 'chat:message', function( msg ) {
+            if( msg.type === 'api' && !msg.rolltemplate ) {
+                var params = msg.content.substring( 1 ).split( ' ' ),
+                    command = params[0].toLowerCase(),
+                    tableName = params[1] ? params[1].toLowerCase() : '',
+                    msgFrom = getFrom( params, msg.playerid );
+                
+                if( command === 'rtm' ) {
+                    findTable( msgFrom, tableName );
+                }
+            }
+        });
+    },
+    
+    getFrom = function( params, playerId ) {
+        // Determine the sender of the messages. Defaults to table name (formatted to title case).
+        var msgFrom = titleCase( params[1].replace( /-/g, ' ' ) );
+        
+        if( params.length > 2 ) {
+            // If the optional third paramater was passed, assign sender to that string or original sender ('myself')
+            msgFrom = params.splice( 2 ).join( ' ' );
+            msgFrom = msgFrom.toLowerCase() == 'myself' ? ( 'player|' + playerId ) : msgFrom;
+        }
+        
+        return msgFrom;
+    },
+    
+    findTable = function( msgFrom, tableName ) {
+        // Finds the corresponding table, outputs error message to chat if not found
+        var tables = findObjs({ type: 'rollabletable', name: tableName });
+        
+        if( tables.length < 1 ) {
+            sendChat( msgFrom, 'No such table exists.' );
+        } else {
+            rollTable( tables[0].id, msgFrom );
+        }
+    },
+    
+    rollTable = function( tableId, msgFrom ) {
+        // Picks an item from the table
+        var items = findObjs({ type: 'tableitem', rollabletableid: tableId }),
+            weightedList = [];
+        
+        _.each( items, function( item ){
+            // Build a weighted list to draw from
+            let weight = item.get( 'weight' );
+            _( weight ).times(function( x ){
+                weightedList.push( item.id );
+            });
+        });
+    
+        var chosenItem = getObj( 'tableitem', weightedList[ randomInteger( weightedList.length ) - 1 ] );
+    
+        sendChat( msgFrom, handleMacro( chosenItem.get( 'name' ) ) );
+    },
+    
+    handleMacro = function( resultText ) {
+        // Recursively handles any macro calls
+        var resultLines = resultText.split( "\n" );
+        
+        _.each( resultLines, function( line, index, resultArray ){
+            var lineArray = line.split( ' ' );
+            
+            _.each( lineArray, function( word, index, parentArray ){
+                if( word[0] === '#' ) {
+                    var macro = findObjs({ type: 'macro', name: word.substring( 1 ) });
+                
+                    parentArray[ index ] = macro.length > 0 ? handleMacro( macro[0].get( 'action' ) ) : word;
+                }
+            });
+            
+            resultArray[ index ] = lineArray.join( ' ' );
+        });
+        
+        return resultLines.join( "\n" );
+    },
+    
+    titleCase = function(str) {
+        // returns the string in title case (each word capitalized)
+        return str.toLowerCase().replace(/(^| )(\w)/g, function(x) {
+            return x.toUpperCase();
+        });
+    };
+    
+};
+
+on( 'ready', function(){
+   'use strict';
+   
+   RollableTableMacros.commandListener();
+});

--- a/RollableTableMacros/RollableTableMacros.js
+++ b/RollableTableMacros/RollableTableMacros.js
@@ -36,7 +36,7 @@ var RollableTableMacros = RollableTableMacros || ( function() {
     
     findTable = function( msgFrom, tableName ) {
         // Finds the corresponding table, outputs error message to chat if not found
-        var tables = findObjs({ type: 'rollabletable', name: tableName });
+        var tables = findObjs({ type: 'rollabletable', name: tableName }, { caseInsensitive: true });
         
         if( tables.length < 1 ) {
             sendChat( msgFrom, 'No such table exists.' );
@@ -50,17 +50,21 @@ var RollableTableMacros = RollableTableMacros || ( function() {
         var items = findObjs({ type: 'tableitem', rollabletableid: tableId }),
             weightedList = [];
         
-        _.each( items, function( item ){
-            // Build a weighted list to draw from
-            let weight = item.get( 'weight' );
-            _( weight ).times(function( x ){
-                weightedList.push( item.id );
+        if( items.length > 0 ) {
+            _.each( items, function( item ){
+                // Build a weighted list to draw from
+                let weight = item.get( 'weight' );
+                _( weight ).times(function( x ){
+                    weightedList.push( item.id );
+                });
             });
-        });
-    
-        var chosenItem = getObj( 'tableitem', weightedList[ randomInteger( weightedList.length ) - 1 ] );
-    
-        sendChat( msgFrom, handleMacro( chosenItem.get( 'name' ) ) );
+        
+            var chosenItem = getObj( 'tableitem', weightedList[ randomInteger( weightedList.length ) - 1 ] );
+        
+            sendChat( msgFrom, handleMacro( chosenItem.get( 'name' ) ) );
+        } else {
+            sendChat( msgFrom, 'No items on this table.' );
+        }
     },
     
     handleMacro = function( resultText ) {

--- a/RollableTableMacros/RollableTableMacros.js
+++ b/RollableTableMacros/RollableTableMacros.js
@@ -2,7 +2,7 @@
 // API Commands:
 // !rtm table-name(required) myself/from-name(optional)
 
-var RollableTableMacros = RollableTableMacros || function() {
+var RollableTableMacros = RollableTableMacros || ( function() {
     'use strict';
     
     var commandListener = function() {
@@ -91,10 +91,14 @@ var RollableTableMacros = RollableTableMacros || function() {
         });
     };
     
-};
+    return {
+        CommandListener: commandListener
+    };
+    
+}());
 
 on( 'ready', function(){
    'use strict';
    
-   RollableTableMacros.commandListener();
+   RollableTableMacros.CommandListener();
 });

--- a/RollableTableMacros/script.json
+++ b/RollableTableMacros/script.json
@@ -3,7 +3,7 @@
 	"script": "RollableTableMacros.js",
 	"version": "1.0",
 	"previousversions": [],
-	"description": "",
+	"description": "# Rollable Table Macros\r\rThis is a simple script that gets an item from a rollable table and enters its name as a chat message rather than showing it as a rollable table result. This allows use of most of the normal features of text chat such as dice rolls, inline rolls, macros, etc. A notable exception is roll queries, which aren't currently supported.\r\rThis will select an item at random from the table, respecting each item's weight. The item's icon, if any, is ignored.\r\r### How to\r\rSimply type `!rtm table-name`. The table name is not case-sensitive. If there are multiple tables with the same name, it will use the first one. If no table by that name is found, or no items are on that table, an error will be output to chat.\r\rYou can include a third paramater in the format `!rtm table-name Sender Name`. This will set the message's 'Speaking As' to whatever string is included after `table-name`.\r\r`!rtm table-name myself` will set the sender of the message to the player who typed in the API command.\r\rIf no third paramater is included, 'Speaking As' will be the formatted name of the table (example: *wild-magic-surge* becomes *Wild Magic Surge*).\r\r#### To do:\r\r* Handle text chat errors (for example, attempting to /w to a wrong name does not output anything)\r* Handle roll queries",
 	"authors": "Nathanael W.",
 	"roll20userid": "880239",
 	"useroptions": [],

--- a/RollableTableMacros/script.json
+++ b/RollableTableMacros/script.json
@@ -1,0 +1,13 @@
+{
+  "name": "Rollable Table Macros",
+	"script": "RollableTableMacros.js",
+	"version": "1.0",
+	"previousversions": [],
+	"description": "",
+	"authors": "Nathanael W.",
+	"roll20userid": "880239",
+	"useroptions": [],
+	"dependencies": [],
+	"modifies": {},
+	"conflicts": []
+}


### PR DESCRIPTION
# Rollable Table Macros

This is a simple script that gets an item from a rollable table and enters its name as a chat message rather than showing it as a rollable table result. This allows use of most of the normal features of text chat such as dice rolls, inline rolls, macros, etc. A notable exception is roll queries, which aren't currently supported.

This will select an item at random from the table, respecting each item's weight. The item's icon, if any, is ignored.