### PR TITLE
Added link in script.json

### DIFF
--- a/COFantasy/README.md
+++ b/COFantasy/README.md
@@ -1,3 +1,3 @@
 ## Chroniques Oubliées Fantasy Script
-For detailed instructions (in French), see doc.html
+For detailed instructions (in French), see [the documentation](http://htmlpreview.github.io/?https://github.com/Ulty/roll20-api-scripts/blob/master/COFantasy/doc.html).
 

--- a/COFantasy/script.json
+++ b/COFantasy/script.json
@@ -3,7 +3,7 @@
   "script": "COFantasy.js",
   "version": "0.1",
   "previousversions": [],
-  "description": "Provides a set of functionalities for the RPG named Chroniques Oubliées Fantasy. Those functionalities concern mostly the fights, and provide automatic support for initiative tracking, attack tests, damages, munitions, and a wide variety of spells, skills and optional rules. In addition, the script allows to undo most actions. For a more detailed description and usage of the commands, read doc.html (in French).",
+  "description": "Provides a set of functionalities for the RPG named Chroniques Oubliées Fantasy. Those functionalities concern mostly the fights, and provide automatic support for initiative tracking, attack tests, damages, munitions, and a wide variety of spells, skills and optional rules. In addition, the script allows to undo most actions. For a more detailed description and usage of the commands, read [the documentation](http://htmlpreview.github.io/?https://github.com/Ulty/roll20-api-scripts/blob/master/COFantasy/doc.html) (in French).",
   "authors": "Ulti",
   "roll20userid": "1794854",
   "useroptions": [],

--- a/COFantasy/script.json
+++ b/COFantasy/script.json
@@ -4,7 +4,7 @@
   "version": "0.1",
   "previousversions": [],
   "description": "Provides a set of functionalities for the RPG named Chroniques Oubliées Fantasy. Those functionalities concern mostly the fights, and provide automatic support for initiative tracking, attack tests, damages, munitions, and a wide variety of spells, skills and optional rules. In addition, the script allows to undo most actions. For a more detailed description and usage of the commands, read doc.html (in French).",
-  "authors": "Laurent Mauborgne",
+  "authors": "Ulti",
   "roll20userid": "1794854",
   "useroptions": [],
   "dependencies": ["Vector_Math"],

--- a/MarchingOrder/2.1/marchingOrder.js
+++ b/MarchingOrder/2.1/marchingOrder.js
@@ -72,7 +72,7 @@ var MarchingOrder = (function() {
       var follower = leader.follower;
       follower.prevLeft = follower.get("left");
       follower.prevTop = follower.get("top");
-      follower.prevRotation = follower.get("rotation")
+      follower.prevRotation = follower.get("rotation");
 
       follower.set("left",leader.prevLeft);
       follower.set("top",leader.prevTop);
@@ -215,7 +215,7 @@ var MarchingOrder = (function() {
 
       // Cardinal directions (GM only)
       if(playerIsGM(playerId)) {
-        actionsHtml += '<div style="text-align: center;">March in order:</div>'
+        actionsHtml += '<div style="text-align: center;">March in order:</div>';
         actionsHtml += '<div><table style="width: 100%;">';
         actionsHtml += '<tr><td></td><td>[North](' + FOLLOW_CMD + ' north)</td><td></td></tr>';
         actionsHtml += '<tr><td>[West](' + FOLLOW_CMD + ' west)</td><td></td><td>[East](' + FOLLOW_CMD + ' east)</td></tr>';
@@ -301,7 +301,7 @@ var MarchingOrder = (function() {
             else if(arg)
                 _cmdFollowNamedToken(tokens, arg);
             else
-                _replyHowToMessage(playerName);
+                _replyHowToMessage(msg);
         }
         else if(_msgStartsWith(msg, MENU_CMD)) {
             _showMenu(msg.who, msg.playerid);


### PR DESCRIPTION
I'd like to add the link to the full documentation in the script.json of COFantasy (and use pseudo for author).

I also committed a small bugfix to MarchinOrder