### PR TITLE
Add One Roll Engine style grouped dice sets

### DIFF
--- a/OneRollEngine/0.1/matchingSets.js
+++ b/OneRollEngine/0.1/matchingSets.js
@@ -1,0 +1,102 @@
+//this script listens for dice rolls and checks them for matching sets
+
+var MatchSets = MatchSets || (function(){
+    'use strict';
+
+    var version = 0.1;
+
+    var useroptions = (globalconfig && 
+      (globalconfig.MatchSets || globalconfig.matchsets)) ||
+      {'Die Size': 10};
+
+    on('chat:message', function(msg) {
+    //This allows players to enter !ma <dice expression> to roll a number of dice and find matches
+    if (msg.type == 'api' && msg.content.indexOf ('!sets ') !== -1) {
+        var dice = msg.content.replace('!sets ', '');
+        sendChat(msg.who, '/roll ' + dice +'sa !sets');
+    }
+    });
+
+    // gets the comments out of all the groups in a set of die rolls
+    function getComment(content) {
+        'use strict';
+        var comment = '';
+
+        content.rolls.forEach(function(roll){
+            if (roll.type == 'C'){
+                comment += roll.text;
+            }
+        });
+        return comment;
+    }
+
+    function needsSets(content){
+        var requestedSets = ( getComment(content).indexOf('!sets') != -1 || content.rolls[0].sides == useroptions['Die Size'] );
+        return requestedSets;
+    }
+
+    function handleInput(msg) {
+        var isRoll = (msg.type == 'rollresult' || msg.type == 'gmrollresult');
+
+        if (isRoll) {
+            var content = JSON.parse(msg.content);
+            var doGetSets = needsSets(content);
+
+            if ( doGetSets ) {
+
+                //create an array to match sides
+                var matches = [null];
+
+                //make an index in the array for each side of the die
+                for (var i = 0; i < content.rolls[0].sides; i++) {
+                    matches.push(0);
+                }
+
+                //get dice reults of first roll
+                var results = content.rolls[0].results;
+
+                //record number of dice for each result
+                for ( var i = 0; i < results.length; i++ ) {
+                    var current_result = results[i].v;
+                    matches[current_result] += 1;
+                }
+
+                //output results
+                var chat_output = ''
+                var separator = ''
+
+                for ( var i = 0; i < matches.length; i++){
+                    if (matches[i] > 1) {
+                        chat_output += separator + ' ``' + matches[i] + 'x' + i + '``' ;
+                        separator = ', '
+                    }
+                }
+
+                if (chat_output.length == 0) { chat_output = 'no sets' }
+
+                if (msg.type == 'gmrollresult') {
+                    sendChat(msg.who,'/w gm got '+chat_output);
+                } else {
+                    sendChat(msg.who,'/em got '+chat_output);
+                }
+            }
+            else return;
+        }
+        else return;
+    }       
+
+    function registerEventHandlers() {
+        on('chat:message', handleInput);
+    }
+
+    return { 
+        registerEventHandlers: registerEventHandlers,
+    }
+}());
+
+
+on('ready',function(){
+    'use strict';
+
+    MatchSets.registerEventHandlers();
+});

--- a/OneRollEngine/README.md
+++ b/OneRollEngine/README.md
@@ -1,0 +1,22 @@
+One Roll Engine for Roll20
+=============
+
+This is a small script to parse matching sets from pools of dice. It is intended to support One Roll Engine games such as Reign and Wild Talents, but could also be used to support any system that requires matching sets of dice from a large pool (eg. Mistborn RPG).
+
+How to use it
+============
+
+There are a few ways to use this utility:
+
+### **Roll some d10's**  
+Just /roll your pool of d10's. The script will append a list of matching sets in Width x Height format after your results.
+
+__Note:__
+If you want to use a different size die, this can be set in the configuration for this script.
+
+### Use the new !sets die roll modifier
+You can add this to any simple XdY roll and it will find sets for you. For example: `/roll 8d10 !sets`. You can combine this with any other dice rules, such as sorting or dropping. `/roll 8d10sa !sets` is the best one to use in your macros,
+since it puts the dice in a nice sorted group.
+
+### Use the !sets API command
+If you use `!sets` followed by a dice pool, it will take care of sorting the dice for you! Great for macros.

--- a/OneRollEngine/script.json
+++ b/OneRollEngine/script.json
@@ -1,0 +1,20 @@
+{
+    "name": "One Roll Engine Matching Sets",
+    "script": "matchingSets.js",
+    "version": "0.1",
+    "previousversions": [],
+    "description": "This script automatically finds sets of matching dice in rolled dice pools. It is intended to support \"Matching Set\" style games like One Roll Engine or Mistborn RPG. It provides an auto-match function along with a !sets roll modifier (see the readme for usage).",
+    "authors": "Ean M.",
+    "roll20userid": "9863",
+    "useroptions": [
+        {
+            "name": "Die Size", 
+            "type": "number",
+            "default": 10,
+            "description": "This is the size of die used in your game's dice pool. The script with automatically find mathces in any dice pool of this size. "
+        }
+    ],
+    "dependencies": [],
+    "modifies": {},
+    "conflicts": []
+}


### PR DESCRIPTION
Provides support for One Roll Engine and other systems that rely on matching sets.

The primary usage is via a user config on the script, which tells it to find sets in any dice pools of a given size (it defaults to d10's). It also provides a roll modifier and API command using the standard "!mod" format, in this case `!sets`. GM Roll support is included, and it intentionally does not interact with inline rolls.

I'd suggest this be placed as a System Toolbox for One Roll Engine, or perhaps as a Chat script if people think it might be more generally useful. Other uses I can think of:

- There are a few other obscure systems like Mistborn RPG that also use matching mechanics.
- Could be used to simulate poker-like card games: `/roll 5d13 !sets` would simulate a poker hand.

Sample output:
<image src="https://user-images.githubusercontent.com/6200445/28242228-282505e6-6974-11e7-860b-1bc75027bc23.png" height="500px">
