### PR TITLE
limit checkForTokenMove to when the token is moved.

### DIFF
--- a/Bloodied and Dead Status Markers/Bloodied and Dead Status Markers.js
+++ b/Bloodied and Dead Status Markers/Bloodied and Dead Status Markers.js
@@ -1,4 +1,4 @@
-on("change:graphic", function(obj) {
+on("change:graphic:bar1_value", function(obj) {
     if(obj.get("bar1_max") === "") return;
    
     if(obj.get("bar1_value") <= obj.get("bar1_max") / 2) {

--- a/TurnMarker1/TurnMarker1.js
+++ b/TurnMarker1/TurnMarker1.js
@@ -676,7 +676,7 @@ var TurnMarker = TurnMarker || (function(){
     registerEventHandlers = function(){        
         on("change:campaign:initiativepage", dispatchInitiativePage );
         on("change:campaign:turnorder", handleTurnOrderChange );
-        on("change:graphic", checkForTokenMove );
+        on("change:graphic:lastmove", checkForTokenMove );
         on("destroy:graphic", handleDestroyGraphic );
         on("chat:message", handleInput );
 


### PR DESCRIPTION
- Previously, it would fire when HP was edited, or the token rotated, etc. This limits how often the code runs for performance.