### PR TITLE
Bugfix

### DIFF
--- a/5th Edition OGL by Roll20 Companion/1.4/5th Edition OGL by Roll20 Companion.js
+++ b/5th Edition OGL by Roll20 Companion/1.4/5th Edition OGL by Roll20 Companion.js
@@ -504,7 +504,7 @@ var handleammo = function (msg,character,player) {
             ammoweight = findObjs({type: 'attribute', characterid: character.id, name: "repeating_inventory_" + ammoitemid + "_itemweight"}, {caseInsensitive: true})[0];
             totalweight = findObjs({type: 'attribute', characterid: character.id, name: "weighttotal"}, {caseInsensitive: true})[0];
             if(ammoweight && totalweight) {
-                totalweight.set({current: totalweight.get("current") - ammoweight.get("current")});
+                totalweight.set({current: totalweight.get("current") - (ammoweight.get("current") * ammonum)});
             }
         }
         var wtype = getAttrByName(character.id, "wtype");


### PR DESCRIPTION
Bug: Ammotracking has support for using multiples of ammunition, but does not add this multiplayer to the weight calculation hence only one of the resources will be removed from the total weight calculation.

Fix: Added multiplayer to the weight subtraction