### PR TITLE
Fixed death saving throws being triggered.

### DIFF
--- a/5th Edition OGL by Roll20 Companion/1.4/5th Edition OGL by Roll20 Companion.js
+++ b/5th Edition OGL by Roll20 Companion/1.4/5th Edition OGL by Roll20 Companion.js
@@ -114,7 +114,8 @@ var handledeathsave = function(msg,character) {
     var result = msg.inlinerolls[0].results.total ? msg.inlinerolls[0].results.total : false;
     var resultbase = msg.inlinerolls[0].results.rolls[0].results[0].v ? msg.inlinerolls[0].results.rolls[0].results[0].v : false;
     var resultoutput = "";
-    if(msg.content.indexOf("{{global=") > -1 && result != false) {
+    // The $ sign means that the a global modifier was used.
+    if(msg.content.indexOf("{{global=$") > -1 && result != false) {
         var global_mod = msg.inlinerolls[1].results.total ? msg.inlinerolls[1].results.total : 0;
         result = result + global_mod;
     }


### PR DESCRIPTION
With the charactermancer update, the global save modifier field has been added to the death saving throw template by default, even when no global save modifier is used ( {{global=}} ). This is causing the companion script to think that the is a global modifier roll, but errors because no roll is found.  This update will ensure that the handledeathsave method only triggers when there actually is a roll in the global save field.