### PR TITLE
Fix #771

### DIFF
--- a/Flight/3.4/Flight.js
+++ b/Flight/3.4/Flight.js
@@ -41,7 +41,6 @@ bshields.flight = (function() {
             markerStr = _.chain(num.toString().split(''))
                 .map((d) => `${marker}@${d}`)
                 .value()
-                .reverse()
                 .join(',');
         }
         


### PR DESCRIPTION
Roll20 recently (a while back now, in all honesty) reversed the order the status markers get rendered. They're now drawn in the "correct" order, so we no longer need to reverse our symbols.