### PR TITLE
Fix event handler object modification

### DIFF
--- a/tokenFate/1.1.0/tokenFate.js
+++ b/tokenFate/1.1.0/tokenFate.js
@@ -53,12 +53,13 @@ var TokenFate = TokenFate || (function() {
 		}
 	},
 
-    handleMessages = function(msg)
+    handleMessages = function(msg_orig)
     {
 		if('api' !== msg.type ) {
 			return;
 		}
-
+	    
+	let msg = _.clone(msg_orig);
         //This sorcery shamelessly taken from The Aaron's Ammo script
         if(_.has(msg,'inlinerolls')){
 			msg.content = _.chain(msg.inlinerolls)

--- a/tokenFate/tokenFate.js
+++ b/tokenFate/tokenFate.js
@@ -53,12 +53,13 @@ var TokenFate = TokenFate || (function() {
 		}
 	},
 
-    handleMessages = function(msg)
+    handleMessages = function(msg_orig)
     {
 		if('api' !== msg.type ) {
 			return;
 		}
-
+	    
+	let msg = _.clone(msg_orig);
         //This sorcery shamelessly taken from The Aaron's Ammo script
         if(_.has(msg,'inlinerolls')){
 			msg.content = _.chain(msg.inlinerolls)


### PR DESCRIPTION
Update made by TheAaron to clone original message object for manipulation so as not to modify the original object before other scripts can see it.