### PR TITLE
Fix two bugs in WildShapeResizer

### DIFF
--- a/WildShapeResizer/0.0.2/WildShapeResizer.js
+++ b/WildShapeResizer/0.0.2/WildShapeResizer.js
@@ -1,0 +1,118 @@
+/* Wild-Shape Token Resizer
+ *
+ * A script to automatically resize a Rollable Table Token when a different
+ * side is chosen. It does this by repurposing the “weight” attribute of the
+ * Items in the Rollable Table. It was written with D&D Druid Wild Shape
+ * tokens in mind, but would work for any square rollable table tokens from
+ * which players will choose different sides.
+ *
+ * The script listens to token:change events, looks for a table with the
+ * same name as the token, and updates the token size when the side changes,
+ * so no other configuration should be required.
+ *
+ * By: Erik Ogan
+ * Version: 0.0.2
+ */
+
+var WildShapeResizer =
+  WildShapeResizer ||
+  (() => {
+    "use strict";
+
+    var version = "0.0.2";
+
+    var checkTokenSize = (token) => {
+      var name = token.get("name");
+      if (!name) return;
+
+      var tableItems = itemsForToken(token);
+      if (!tableItems || tableItems.length < 1) return;
+
+      var page = getObj("page", token.get("_pageid"));
+      var gridSize = 70;
+
+      if (page) {
+        gridSize = page.get("snapping_increment") * gridSize;
+      }
+
+      var side = tableItems[token.get("currentSide")];
+      if (side.get("avatar") !== token.get("imgsrc")) {
+        // Rollable Table sides are copied into the token when it is created. If you change the table
+        log("WildShapeResizer ERROR: token image does not match table image");
+        sendChat(
+          "WildShapeResizer",
+          "/direct <strong>ERROR:</strong> token image does not match table image." +
+            " This token likely needs to be recreated."
+        );
+        return;
+      }
+
+      var weight = side.get("weight");
+      var dimension = gridSize * weight;
+      doResize(token, dimension);
+    };
+
+    var doResize = (token, dimension) => {
+      var name = token.get("name");
+
+      var currentW = token.get("width");
+      var currentH = token.get("height");
+
+      // TODO: get the locations of the other tokens on the board and try to keep from overlapping them
+      var currentL = token.get("left");
+      var currentT = token.get("top");
+
+      if (
+        currentW &&
+        currentH &&
+        (currentW !== dimension || currentH !== dimension)
+      ) {
+        log(`WildShapeResizer: resizing ${name} to ${dimension}`);
+        token.set("width", dimension);
+        token.set("height", dimension);
+        // TODO: Figure out why this is not working
+        // Reset top & left so it does not center on the old size
+        token.set("top", currentT);
+        token.set("left", currentL);
+        // Maybe with a timeout after we’ve finished our changes?
+        setTimeout(() => {
+          token.set("top", currentT);
+          token.set("left", currentL);
+        }, 10);
+      } else {
+        log(`WildShapeResizer: ${name} is already correctly sized.`);
+      }
+    };
+
+    var itemsForToken = (token) => {
+      var name = token.get("name");
+      if (!name) return undefined;
+
+      var table = findObjs({ _type: "rollabletable", name: name })[0];
+      if (!table) return undefined;
+
+      return findObjs({
+        _type: "tableitem",
+        _rollabletableid: table.id,
+      });
+    };
+
+    var registerHandlers = () => {
+      on("change:token", checkTokenSize);
+    };
+
+    var notifyStart = () => {
+      log(`.oO WildShapeResizer ${version} Oo.`);
+    };
+
+    return {
+      notifyStart: notifyStart,
+      registerHandlers: registerHandlers,
+    };
+  })();
+
+on("ready", () => {
+  "use strict";
+  WildShapeResizer.notifyStart();
+  WildShapeResizer.registerHandlers();
+});

--- a/WildShapeResizer/0.0.2/WildShapeResizer.js
+++ b/WildShapeResizer/0.0.2/WildShapeResizer.js
@@ -20,6 +20,7 @@ var WildShapeResizer =
     "use strict";
 
     const version = "0.0.2";
+    const defaultGridSize = 70;
 
     const checkTokenSize = (token) => {
       const name = token.get("name");
@@ -29,10 +30,14 @@ var WildShapeResizer =
       if (!tableItems || tableItems.length < 1) return;
 
       const page = getObj("page", token.get("_pageid"));
-      let gridSize = 70;
+      let gridSize = defaultGridSize;
 
       if (page) {
         gridSize = page.get("snapping_increment") * gridSize;
+      }
+
+      if (gridSize <= 0) {
+        gridSize = defaultGridSize;
       }
 
       const side = tableItems[token.get("currentSide")];

--- a/WildShapeResizer/0.0.2/WildShapeResizer.js
+++ b/WildShapeResizer/0.0.2/WildShapeResizer.js
@@ -41,7 +41,7 @@ var WildShapeResizer =
       }
 
       const side = tableItems[token.get("currentSide")];
-      if (side.get("avatar") !== token.get("imgsrc")) {
+      if (!imageCompare(side.get("avatar"), token.get("imgsrc"))) {
         // Rollable Table sides are copied into the token when it is created. If you change the table
         log("WildShapeResizer ERROR: token image does not match table image");
         sendChat(
@@ -101,6 +101,16 @@ var WildShapeResizer =
         _rollabletableid: table.id,
       });
     };
+
+    const imageCompare = (img1, img2) => {
+      return imageNormalize(img1) === imageNormalize(img2);
+    }
+
+    const imageNormalize = (img) => {
+      img = img.replace(/\?.*$/, '');
+      img = img.replace(/(.*)\/[^.]+/, '$1/max');
+      return img;
+    }
 
     const registerHandlers = () => {
       on("change:token", checkTokenSize);

--- a/WildShapeResizer/0.0.2/WildShapeResizer.js
+++ b/WildShapeResizer/0.0.2/WildShapeResizer.js
@@ -14,7 +14,7 @@
  * Version: 0.0.2
  */
 
-const WildShapeResizer =
+var WildShapeResizer =
   WildShapeResizer ||
   (() => {
     "use strict";

--- a/WildShapeResizer/0.0.2/WildShapeResizer.js
+++ b/WildShapeResizer/0.0.2/WildShapeResizer.js
@@ -14,28 +14,28 @@
  * Version: 0.0.2
  */
 
-var WildShapeResizer =
+const WildShapeResizer =
   WildShapeResizer ||
   (() => {
     "use strict";
 
-    var version = "0.0.2";
+    const version = "0.0.2";
 
-    var checkTokenSize = (token) => {
-      var name = token.get("name");
+    const checkTokenSize = (token) => {
+      const name = token.get("name");
       if (!name) return;
 
-      var tableItems = itemsForToken(token);
+      const tableItems = itemsForToken(token);
       if (!tableItems || tableItems.length < 1) return;
 
-      var page = getObj("page", token.get("_pageid"));
-      var gridSize = 70;
+      const page = getObj("page", token.get("_pageid"));
+      let gridSize = 70;
 
       if (page) {
         gridSize = page.get("snapping_increment") * gridSize;
       }
 
-      var side = tableItems[token.get("currentSide")];
+      const side = tableItems[token.get("currentSide")];
       if (side.get("avatar") !== token.get("imgsrc")) {
         // Rollable Table sides are copied into the token when it is created. If you change the table
         log("WildShapeResizer ERROR: token image does not match table image");
@@ -47,20 +47,20 @@ var WildShapeResizer =
         return;
       }
 
-      var weight = side.get("weight");
-      var dimension = gridSize * weight;
+      const weight = side.get("weight");
+      const dimension = gridSize * weight;
       doResize(token, dimension);
     };
 
-    var doResize = (token, dimension) => {
-      var name = token.get("name");
+    const doResize = (token, dimension) => {
+      const name = token.get("name");
 
-      var currentW = token.get("width");
-      var currentH = token.get("height");
+      const currentW = token.get("width");
+      const currentH = token.get("height");
 
       // TODO: get the locations of the other tokens on the board and try to keep from overlapping them
-      var currentL = token.get("left");
-      var currentT = token.get("top");
+      const currentL = token.get("left");
+      const currentT = token.get("top");
 
       if (
         currentW &&
@@ -84,11 +84,11 @@ var WildShapeResizer =
       }
     };
 
-    var itemsForToken = (token) => {
-      var name = token.get("name");
+    const itemsForToken = (token) => {
+      const name = token.get("name");
       if (!name) return undefined;
 
-      var table = findObjs({ _type: "rollabletable", name: name })[0];
+      const table = findObjs({ _type: "rollabletable", name: name })[0];
       if (!table) return undefined;
 
       return findObjs({
@@ -97,11 +97,11 @@ var WildShapeResizer =
       });
     };
 
-    var registerHandlers = () => {
+    const registerHandlers = () => {
       on("change:token", checkTokenSize);
     };
 
-    var notifyStart = () => {
+    const notifyStart = () => {
       log(`.oO WildShapeResizer ${version} Oo.`);
     };
 

--- a/WildShapeResizer/script.json
+++ b/WildShapeResizer/script.json
@@ -1,8 +1,8 @@
 {
     "name": "WildShapeResizer",
     "script": "WildShapeResizer.js",
-    "version": "0.0.1",
-    "previousversions": [],
+    "version": "0.0.2",
+    "previousversions": ["0.0.1"],
     "description": "A script to automatically resize a Rollable Table Token when a different side is chosen. It does this by repurposing the “weight” attribute of the Items in the Rollable Table. It was written with D&D Druid Wild Shape tokens in mind, but would work for any square rollable table tokens from which players will choose different sides.\nThe script listens to token:change events, looks for a table with the same name as the token, and updates the token size when the side changes, so no other configuration should be required.",
     "authors": "Erik O.",
     "roll20userid": "1828947",


### PR DESCRIPTION
Version 0.0.2 fixes the following:

* Tokens copied from one map page to another throw errors until they are reset by selecting (or rolling) another side from the table.
* Tokens are resized to 0×0 when on a map without grid snapping

Cleanup:
Migrate to using ES6 const/let declarations, to make clear which variables actually vary.