### PR TITLE
Fumbler: Increase robustness and updated README

### DIFF
--- a/Fumbler/0.2.0/Fumbler.js
+++ b/Fumbler/0.2.0/Fumbler.js
@@ -155,8 +155,8 @@ var fumbler = fumbler || (function()
 				{
 					try
 					{
-                       notes = notes.replace( /(<([^>]+)>)/ig, '');
-                       notes = notes.replace(/&nbsp;/gi, '') // Coder error. Not sure how to incorporate this regex to the above
+                        notes = notes.replace( /(<([^>]+)>)/ig, '');
+                        notes = notes.replace(/&nbsp;/gi, '') // Coder error. Not sure how to incorporate this regex to the above
 						chart = JSON.parse(notes);
 						chart.sort(sort_json_by_low)
 						let bounded_roll = ((rolled > chart[chart.length - 1].high ) ? randomInteger(chart[chart.length - 1].high) : rolled) // if a custom chart is allowed, roll up to whatever the maximum value specified is

--- a/Fumbler/0.2.0/Fumbler.js
+++ b/Fumbler/0.2.0/Fumbler.js
@@ -155,8 +155,8 @@ var fumbler = fumbler || (function()
 				{
 					try
 					{
-                        notes = notes.replace( /(<([^>]+)>)/ig, '');
-                        notes = notes.replace(/&nbsp;/gi, '') // Coder error. Not sure how to incorporate this regex to the above
+						notes = notes.replace( /(<([^>]+)>)/ig, '');
+						notes = notes.replace(/&nbsp;/gi, '') // Coder error. Not sure how to incorporate this regex to the above
 						chart = JSON.parse(notes);
 						chart.sort(sort_json_by_low)
 						let bounded_roll = ((rolled > chart[chart.length - 1].high ) ? randomInteger(chart[chart.length - 1].high) : rolled) // if a custom chart is allowed, roll up to whatever the maximum value specified is
@@ -176,7 +176,7 @@ var fumbler = fumbler || (function()
 	},
 
 	/**
-	 * Handle chat events
+	 * Sort json object list by "low" attribute
 	 *
 	 * @param {object} x
 	 * @param {object} y

--- a/Fumbler/0.2.0/Fumbler.js
+++ b/Fumbler/0.2.0/Fumbler.js
@@ -155,9 +155,12 @@ var fumbler = fumbler || (function()
 				{
 					try
 					{
-						notes = notes.split(/<[/]?.+?>/g).join('');
+				        notes = notes.replace( /(<([^>]+)>)/ig, '');
+				        notes = notes.replace(/&nbsp;/gi, '') // Coder error. Not sure how to incorporate this regex to the above
 						chart = JSON.parse(notes);
-						showFumble(chart, rolled)
+						chart.sort(sort_json_by_low)
+						let bounded_roll = ((rolled > chart[chart.length - 1].high ) ? randomInteger(chart[chart.length - 1].high) : rolled) // if a custom chart is allowed, roll up to whatever the maximum value specified is
+						showFumble(chart, bounded_roll)
 					}
 					catch (err)
 					{
@@ -171,6 +174,22 @@ var fumbler = fumbler || (function()
 			sendChat('Fumbler', 'Can not find the fumble chart handout named: ' + fumbleParams[0]);
 		}
 	},
+
+	/**
+	 * Handle chat events
+	 *
+	 * @param {object} x
+	 * @param {object} y
+	 */
+	 sort_json_by_low = function(x,y){
+		 if(x.low < y.low){
+			 return -1;
+		 }
+		 else if(x.low > y.low){
+			 return 1
+		 }
+		 return 0
+	 },
 
 	/**
 	 * Handle chat events

--- a/Fumbler/0.2.0/Fumbler.js
+++ b/Fumbler/0.2.0/Fumbler.js
@@ -155,8 +155,8 @@ var fumbler = fumbler || (function()
 				{
 					try
 					{
-				        notes = notes.replace( /(<([^>]+)>)/ig, '');
-				        notes = notes.replace(/&nbsp;/gi, '') // Coder error. Not sure how to incorporate this regex to the above
+                       notes = notes.replace( /(<([^>]+)>)/ig, '');
+                       notes = notes.replace(/&nbsp;/gi, '') // Coder error. Not sure how to incorporate this regex to the above
 						chart = JSON.parse(notes);
 						chart.sort(sort_json_by_low)
 						let bounded_roll = ((rolled > chart[chart.length - 1].high ) ? randomInteger(chart[chart.length - 1].high) : rolled) // if a custom chart is allowed, roll up to whatever the maximum value specified is

--- a/Fumbler/README.md
+++ b/Fumbler/README.md
@@ -33,11 +33,37 @@ In the notes place JSON code in the format:
 
 ```
 [
-    {low: 1,  high: 10, result: "Distracted", effect: "Roll DEX or fall down."},
-    {low: 11, high: 14, result: "Negligent", effect: "Fall down."},
+    {"low": 1,  "high": 10, "result": "Distracted", "effect": "Roll DEX or fall down."},
+    {"low": 11, "high": 14, "result": "Negligent", "effect": "Fall down."},
     ...
 ]
 ```
+
+When creating this table, it's import there are no gaps in between your possible fumbles.
+Something such as: 
+
+```
+[
+    {"low": 1, "high":10, "result": "Some Result", "effect": "Some effect."},
+    {"low": 15, "high":20, "result": "Other Result", "effect": "Other effect."}
+]
+```
+
+will cause the an (occational) invalid percent error.
+
+Also note that the fumble table does not have to be completed to 100.
+Something such as: 
+
+```
+[
+    {"low": 1,  "high": 10, "result": "Distracted", "effect": "Roll DEX or fall down."},
+    {"low": 11, "high": 14, "result": "Negligent", "effect": "Fall down."},
+    {"low": 15, "high": 25, "result": "Bad", "effect": "Start crying."},
+    {"low": 26, "high": 35, "result": "Very Bad", "effect": "You accidently target a friend."},
+]
+```
+
+will work fine.
 
 To use your fumbler handout chart set the first parameter as your chart name. For example if you created a handout named fumbler-disaster then you can tell fumbler to use it like so:
 


### PR DESCRIPTION
**Purpose:**  Fix fumbler issues found in #993  

**Causes:**  README is misleading users and dice rolls assume custom fumbler tables will always have a high of 100.  

**Changes:**   Updated the README to use valid JSON, and added some examples of good and bad custom fumbler tables. I also bounded the dice rolls when using a custom fumbler table to the max value of that table and added a utility function that would sort the fumbler table by their 'low' attributes. 

In the process of these changes, I realized that the text parsing for custom fumbler tables would fail if one used the tab character in their custom fumbler tables, so I updated the text parsing to account for that as well and figured I'd put it in this PR since it was only one line changed. 

Closes #993 
