### PR TITLE
approved.yaml - It's a Trap Burn Bryte theme

### DIFF
--- a/approved.yaml
+++ b/approved.yaml
@@ -418,6 +418,10 @@ itsatrapthemestarfinder:
 - "ItsATrap_theme_Starfinder"
 - "System Toolbox"
 
+itsatrapthemeburnbryte:
+- "ItsATrap_theme_BurnBryte"
+- "System Toolbox"
+
 genesysroller:
 - "Genesys-RPG-Roller"
 - "System Toolbox"
@@ -869,6 +873,3 @@ fotncompanion:
 hiddenrollmessages:
   - "HiddenRollMessages"
   - "Utility"
-
-
-


### PR DESCRIPTION
The It's a Trap Burn Bryte theme script never got added to approved.yaml when the initial PR for it was merged. I'd like it to be added to the One-Click library, please.