### PR TITLE
Adding approved for WildHelpers

### DIFF
--- a/approved.yaml
+++ b/approved.yaml
@@ -790,6 +790,10 @@ wildshape:
   - "WildShape"
   - "Utility"
 
+wildhelpers:
+  - "WildHelpers"
+  - "Utility"
+
 savageworldsstatuschanger:
   - "SavageWorldsStatusChanger"
   - "System Toolbox"


### PR DESCRIPTION
`WildHelpers` is a dependency for `WildShape`.  Not having it in the approved file prevents the 1-click install of `WildShape` from working.

re: https://app.roll20.net/forum/post/9113273/one-click-install-dependency-not-working/?pageforid=9136675