### PR TITLE
Remove outdated API ItsATrap_theme_5E_OGL and Shaped

### DIFF
--- a/approved.yaml
+++ b/approved.yaml
@@ -164,6 +164,7 @@ customfx:
 itsatraptheme5eshaped:
 - "ItsATrap_theme_5E_Shaped"
 - "System Toolbox"
+- "hidden"
 
 roleplayingismagic4edice:
 - "RoleplayingIsMagic_4E_Dice"
@@ -224,6 +225,7 @@ htmlbuilder:
 itsatraptheme5eogl:
 - "ItsATrap_theme_5E_OGL"
 - "System Toolbox"
+- "hidden"
 
 itsatrapthemepathfindersimple:
 - "ItsATrap_theme_PathfinderSimple"


### PR DESCRIPTION
* fixes #950, per request of the author of the scripts.
* the generic 5E "It's a trap" have long existed as replacement for the two older API