### PR TITLE
Unlist two APIs as requested by author

### DIFF
--- a/approved.yaml
+++ b/approved.yaml
@@ -161,10 +161,6 @@ customfx:
 - "Custom FX"
 - "Maps & Drawing"
 
-itsatraptheme5eshaped:
-- "ItsATrap_theme_5E_Shaped"
-- "System Toolbox"
-- "hidden"
 
 roleplayingismagic4edice:
 - "RoleplayingIsMagic_4E_Dice"
@@ -222,10 +218,6 @@ htmlbuilder:
 - "HtmlBuilder"
 - "Utility"
 
-itsatraptheme5eogl:
-- "ItsATrap_theme_5E_OGL"
-- "System Toolbox"
-- "hidden"
 
 itsatrapthemepathfindersimple:
 - "ItsATrap_theme_PathfinderSimple"


### PR DESCRIPTION
Unlist two APIs, as requested in Issue #950.

There was an attempt to do this with PR #1106, but as described in issue #1136, adding "hidden" to an API in `approved.yaml` doesn't work like it does in the character sheet repo, so the only way to unlist APIs is to remove their entry from the file altogether.