### PR TITLE
Update Categories of several wrongly labeld APIs

### DIFF
--- a/approved.yaml
+++ b/approved.yaml
@@ -207,8 +207,8 @@ itsatrapthemepathfinder:
 - "System Toolbox"
 
 falloutterminal:
-- "FalloutTerminal"
-- "System Toolbox"
+  - "FalloutTerminal"
+  - "Utility"
 
 chatsetattr:
 - "ChatSetAttr"
@@ -309,7 +309,7 @@ healthcolors:
 
 truepagecopy:
 - "TruePageCopy"
-- "Character"
+- "Maps & Drawing"
 - "hidden"
 
 srrollextender:
@@ -382,7 +382,7 @@ onerollengine:
 
 changetokenimage:
 - "ChangeTokenImage"
-- "Utility"
+- "Tokens"
 
 5ebattlemaster:
 - "5EBattleMaster"
@@ -490,7 +490,7 @@ inspirationtrack:
 
 syncpage:
 - SyncPage
-- Utility
+- "Maps & Drawing"
 
 combattracker:
 - CombatTracker
@@ -498,11 +498,11 @@ combattracker:
 
 movelighting:
 - moveLighting
-- Utility
+- "Dynamic Lighting"
 
 elevation:
-- Elevation
-- Utility
+  - Elevation
+  - "Dynamic Lighting"
 
 hero6playable:
 - HeroSystem6e
@@ -510,7 +510,7 @@ hero6playable:
 
 publicsheet:
 - PublicSheet
-- Utility
+- "Character"
 
 gmsheet:
 - GMSheet
@@ -590,7 +590,7 @@ charsheetutils:
 
 healthstatus:
   - "Health Status"
-  - "Utility"
+  - "Tokens"
 
 difficultyrating:
   - "DifficultyRating"
@@ -610,7 +610,7 @@ handsup:
 
 gmaura:
   - "GMAura"
-  - Utility
+  - "Tokens"
 
 savageworldsraiseroller:
   - 'Savage Worlds Raise Roller'
@@ -622,7 +622,7 @@ knightstylesmarkers:
 
 emas:
   - 'Emas'
-  - System Toolbox
+  - 'Chat'
 
 pcpp:
   - 'PCPP'
@@ -650,7 +650,7 @@ talesfromtheloopdierolelr:
 
 flight:
   - 'Flight'
-  - 'Utility'
+  - "Tokens"
 
 shadowofdemonlord:
   - 'Shadow of the Demon Lord'
@@ -662,11 +662,11 @@ myz:
 
 doorknocker:
   - 'Door Knocker'
-  - 'Utility'
+  - "Dynamic Lighting"
 
 randomrotate:
   - 'RandomRotate'
-  - 'Utility'
+  - "Tokens"
 
 dealer:
   - 'Dealer'
@@ -674,11 +674,11 @@ dealer:
 
 facing:
   - 'Facing'
-  - 'Utility'
+  - "Tokens"
 
 wilddice:
   - 'WildDice'
-  - 'Utility'
+  - "System Toolbox"
 
 aligmenttracker:
   - 'AlignmentTracker'
@@ -686,7 +686,7 @@ aligmenttracker:
 
 modifytokenimage:
   - ModifyTokenImage
-  - 'Utility'
+  - "Tokens"
 
 apiheartbeat:
   - 'APIHeartBeat'
@@ -694,19 +694,19 @@ apiheartbeat:
 
 fliptoken:
   - 'Flip Tokens'
-  - 'Utility'
+  - "Tokens"
 
 coloremote:
   - 'ColorEmote'
-  - 'Utility'
+  - 'Chat'
 
 colorenote:
   - 'ColorNote'
-  - 'Utility'
+  - 'Chat'
 
 sharevision:
   - 'ShareVision'
-  - 'Utility'
+  - "Dynamic Lighting"
 
 peekcard:
   - 'PeekCard'
@@ -714,7 +714,7 @@ peekcard:
 
 markingconditions:
   - 'Marking Conditions'
-  - System Toolbox
+  - "Tokens"
 
 imperialcalendar:
   - 'ImperialCalendar'
@@ -734,7 +734,7 @@ base64:
 
 dryerase:
   - "DryErase"
-  - "Utility"
+  - "Maps & Drawing"
 
 maplock:
   - "MapLock"
@@ -758,7 +758,7 @@ tableexport:
 
 tokencondition:
   - "TokenCondition"
-  - "Utility"
+  - "Tokens"
 
 libtokenmrkers:
   - "libTokenMarkers"
@@ -806,7 +806,7 @@ savageworldsstatuschanger:
 
 midgardturntrackerhelper:
   - "MidgardTurnTrackerHelper"
-  - "Utility"
+  - "System Toolbox"
 
 shortrest:
   - "ShortRest"
@@ -814,7 +814,7 @@ shortrest:
 
 tokenmarker:
   - "TokenMarker"
-  - "Utility"
+  - "Tokens"
 
 heroroller:
   - "HeroRoller"
@@ -826,7 +826,7 @@ universalvttimport:
 
 udlwindows:
   - "UDLWindows"
-  - "Utility"
+  - "Dynamic Lighting"
 
 supernotes:
   - "Supernotes"
@@ -834,7 +834,7 @@ supernotes:
 
 changemapclonetokens:
   - "ChangeMap_CloneTokens"
-  - "Utility"
+  - "Maps & Drawing"
 
 restandrecovery:
   - "Rest-and-Recovery"
@@ -842,7 +842,7 @@ restandrecovery:
 
 tokenactionmarker:
   - "Token-Action-Maker"
-  - "Utility"
+  - "Tokens"
 
 5erestinstyle:
   - "5E Resting in Style"
@@ -850,11 +850,11 @@ tokenactionmarker:
 
 huntersmark:
   - "HuntersMark"
-  - "Utility"
+  - "Tokens"
 
 spintokens:
   - "SpinTokens"
-  - "Utility"
+  - "Tokens"
 
 agonecleanolds:
   - "AgoneCleanOlds"
@@ -866,7 +866,7 @@ deltagreenrpgcompanion:
 
 dynamiclightrecorder:
   - "DynamicLightRecorder"
-  - "Utility"
+  - "Dynamic Lighting"
 
 gofish:
   - "GoFish!"
@@ -886,7 +886,7 @@ fotncompanion:
 
 hiddenrollmessages:
   - "HiddenRollMessages"
-  - "Utility"
+  - "Chat"
 
 dkrystal:
   - "KrystalDice"
@@ -898,7 +898,7 @@ paladinaura:
 
 dldarkness:
   - "DL Darkness"
-  - "Utility"
+  - "Dynamic Lighting"
 
 dsacritchecker:
   - "DSA4_1-CritChecker"
@@ -922,7 +922,7 @@ rolltablehandouts:
 
 dealinit:
   - "Deal-Init"
-  - "System Tooolbox"
+  - "System Toolbox"
 
 teleport:
   - "Teleport"


### PR DESCRIPTION
There are several APIs that have been incorrectly labeled under "System Toolbox"(meant for APIs dedicated to specific rpg systems", as well as being filed under heavily overused "Utilities".

Changed a bunch of "Utilities" APIs to be more appropriately listed under "Tokens", "Chat", "Maps & Drawings", "Dynamic Lighting".

There would be a good reason to make more categories for APIs, here being my main suggestions:
- **Combat**, due to the large pile of Combat & Initiative APIs
- **D&D 5E**,due to the massive amount of APIs specialized for the system and to be compatible with the **D&D 5E by Roll20**-sheet
- **API Extension Libraries**, due to the number of APIs that aren't meant for users directly, but to be utilized by other APIs. Creating a separate category for them and listing them at the bottom of the menu would reduce the bloat in the "Utilities" category.