### PR TITLE
Update cypher_systems_by_roll20.js

### DIFF
--- a/Cypher Systems by Roll20 Companion/1.001/cypher_systems_by_roll20.js
+++ b/Cypher Systems by Roll20 Companion/1.001/cypher_systems_by_roll20.js
@@ -15,10 +15,10 @@ var CypherSystemsByRoll20 = CypherSystemsByRoll20 || (function () {
     modStat = function (characterObj,statName,statCost) {
         // checking the stat
 	    var stat1 = "";
-	    if(statName == "might" || statName == "speed" || statName == "intellect" || statName=="recovery-rolls") {
+	    if(statName == "might" || statName == "speed" || statName == "intellect" || statName=="recovery-rolls" || statName=="xp") {
 	        stat1 = statName;
 	    } else {
-	        sendChat("character|"+charId, "&{template:cyphMsg} {{modStat=1}} {{noAttribute=" + statName + "}}");
+	        sendChat("character|"+characterObj.id, "&{template:cyphMsg} {{modStat=1}} {{noAttribute=" + statName + "}}");
 	        return;
 	    };
         if(stat1 == "recovery-rolls"){
@@ -37,6 +37,19 @@ var CypherSystemsByRoll20 = CypherSystemsByRoll20 || (function () {
     	        objArray[0].setWithWorker("current",statCost);
     	    };
             sendChat("character|"+characterObj.id, "Next recovery action updated.");
+        } else if (stat1 == "xp") {
+    	    var objArray = findObjs({
+    	                    _type: 'attribute',
+    	                    name: stat1,
+    	                    _characterid: characterObj.id
+    	                });
+	    obj1 = objArray[0];
+	    var currentXpValue = 0;
+	    var finalXpValue = 0;
+	    currentXpValue=parseInt(obj1.get("current")) || 0;
+	    finalXpValue = currentXpValue + parseInt(statCost);
+	    obj1.setWithWorker("current",finalXpValue);
+	    sendChat("character|"+characterObj.id, "" + stat1 + ": " + currentXpValue + "+" + statCost + "=" + finalXpValue);
         } else {
             //stat pool modification
     	    var pool1 = 0;


### PR DESCRIPTION
Add XP as a valid stat to be modified by the "!cypher-modstat" function. The statcost is added (or subtracted if negative) from the character's XP total. This is useful in conjunction with the use of XP tokens as a deck, especially in conjunction with Keith Curtis's "Dealer" script (which makes dealing cards to and taking cards from players into API calls) to keep the user's number of XP card tokens and the user's XP total in sync.

Also, corrects the chat message that gets sent when an unknown attribute is used, since the "charId" variable is not yet defined at that point; using an unknown attribute prior to this change causes the script to crash in the API console.