### PR TITLE
initial commit of Velvet Generation support script

### DIFF
--- a/Velvet Generation/script.json
+++ b/Velvet Generation/script.json
@@ -1,0 +1,21 @@
+{
+  "name": "VelvetGeneration",
+  "script": "vg.js",
+  "version": "0.1",
+  "description": "This is a set of API helpers for Velvet Generation.\n* It automatically sets all d6 dice dragged from chat onto the table to be controlled by all players.\n* It enables the `!amped` command, which rerolls all 1s in a selection\n* It enables the `onFire|*` command, which sets all 1s in a selection to the number indicated by *.",
+  "authors": "Rich Ranallo",
+  "roll20userid": "104025",
+  "patreon": "https://www.patreon.com/shdwjk",
+  "useroptions": [
+    {
+      "name": "Players can use --ids",
+      "type": "checkbox",
+      "description": "Select this option to allow players to use the `--ids` parameter to specify tokens they don't control to be modified.",
+      "value": "playersCanIDs"
+    }
+  ],
+  "dependencies": [],
+  "modifies": {},
+  "conflicts": [],
+  "previousversions": []
+}

--- a/Velvet Generation/vg.js
+++ b/Velvet Generation/vg.js
@@ -1,0 +1,77 @@
+
+on('ready',()=>{
+  // applies a given effect to a single token
+  function dieEffect(dieToken, effect) {
+    let dieProps = {
+      left: dieToken.get('left'),
+      top: dieToken.get('top')
+    }
+    spawnFx(dieProps.left, dieProps.top, effect);
+  }
+
+  // sets a die token to a given value
+  function setDieValue(dieToken, value) {
+    const boundedVal = Math.min(Math.max(value,0),5)
+    const sides = dieToken.get('sides').replaceAll('%3A', ':').replaceAll('%3F', '?').split('|')
+    const sideImg = sides[boundedVal]
+    dieToken.set({
+      imgsrc: sideImg,
+      currentSide: boundedVal
+    })
+  }
+
+  // regex statements used to match commands
+  const ampedRegex = new RegExp(/^!amped/)
+  const onFireRegex = new RegExp(/^!onFire\|/)
+  const digitRegex = new RegExp(/(?<=\|)\d/)
+
+  //images used for sides of a d6
+  const d6Sides = [
+    'images/779533',
+    'images/779535',
+    'images/779534',
+    'images/779531',
+    'images/779532',
+    'images/779536'
+    ]
+  // recognizes d6s dragged from the chat window onto the tabletop and sets them to be controlled by all players
+  on('add:token', tok=>{
+    log(tok)
+    if(_.every(d6Sides, side => {
+      log(side)
+      log(tok.get('sides'))
+      return tok.get('sides').includes(side)
+    })) {
+      tok.set('controlledby', 'all')
+    }
+  })
+
+  //powers !amped and !onFire|* statements.
+  //!amped rerolls all 1s in the selected dice
+  //!onFire|* sets all 1s in the selection to the value inidcated by *
+  //both apply a visual effect to the dice
+  on("chat:message", msg => {
+    if(msg.type === 'api' &&  msg.selected){
+      msg.selected.forEach(die =>{
+        if (die._type === 'graphic') {
+          let dieToken = getObj('graphic', die._id)
+          if(dieToken.get('currentSide')===0){
+            if(msg.content.match(ampedRegex)){
+              dieEffect(dieToken, 'explode-charm')
+              const newValue = Math.floor(Math.random() * 6)
+              setDieValue(dieToken, newValue)
+            }
+            if(msg.content.match(onFireRegex)){
+              const requestedValue = msg.content.match(digitRegex)
+              if(requestedValue && requestedValue[0]) {
+                setDieValue(dieToken, parseInt(requestedValue)-1)
+                dieEffect(dieToken, 'burst-fire')
+              }
+            }          
+          }
+        }
+      })
+    }
+  })
+
+})


### PR DESCRIPTION
This is a support script for Velvet Generation, enabling some of the weird stuff we need to do with dice in that system. As the description says, it does the following:
 * makes all d6 dice dragged onto the table from chat controllable by all players (players need to move dice around the tabletop, even if they were rolled by others).
 * adds a command for `!amped`, which acts on all selected dice tokens and rerolls any that are set to 1, with a visual effect to indicate it.
 * adds a command for `onFire|*` which acts on all selected dice tokens and sets all 1s to the number indicated by `*`, with a visual effect to indicate it.