### PR TITLE
Fixed incorrectly-included patreon link

### DIFF
--- a/Velvet Generation/script.json
+++ b/Velvet Generation/script.json
@@ -1,11 +1,10 @@
 {
-  "name": "VelvetGeneration",
+  "name": "Velvet Generation",
   "script": "vg.js",
   "version": "0.1",
   "description": "This is a set of API helpers for Velvet Generation.\n* It automatically sets all d6 dice dragged from chat onto the table to be controlled by all players.\n* It enables the `!amped` command, which rerolls all 1s in a selection\n* It enables the `onFire|*` command, which sets all 1s in a selection to the number indicated by *.",
   "authors": "Rich Ranallo",
   "roll20userid": "104025",
-  "patreon": "https://www.patreon.com/shdwjk",
   "useroptions": [
     {
       "name": "Players can use --ids",


### PR DESCRIPTION
The `patreon` prop in `script.json` got left in from whichever one I copied as a template, so it's removed.
I didn't realize that `name` was the label that would be used in the API selector, so I added a space.