### PR TITLE
DrD2LinkedTenacity new script

### DIFF
--- a/DrD2LinkedTenacity/0.1.0/DrD2LinkedTenacity.js
+++ b/DrD2LinkedTenacity/0.1.0/DrD2LinkedTenacity.js
@@ -1,0 +1,92 @@
+// Github:   TBD
+// By:       nesuprachy
+// Contact:  https://app.roll20.net/users/11071738/nesuprachy
+//
+// This script tracks changes made to the 'tenacity_current' attribute and propagates them to other sheets linked via the 'npc_owner' attribute.
+// Uses ChatSetAttr mod to change attributes from chat https://github.com/Roll20/roll20-api-scripts/tree/master/ChatSetAttr#readme
+
+var DrD2LinkedTenacity = DrD2LinkedTenacity || (function() {
+    'use strict';
+    
+    const version = '0.1.0';
+    const lastUpdate = '1715082359599';
+        
+    checkInstall = function () {
+        log(`-=> DrD2LinkedTenacity v${version} <=-  [${new Date(lastUpdate*1000)}]`);
+    },
+
+    handleAttribute = function (obj, prev, isMax) {
+        if(obj.get('name') === 'tenacity_current') {
+            var prevVal, newVal = 0;
+            if(isMax){
+                prevVal = parseInt(prev.max)||0;
+                newVal = parseInt(obj.get('max'))||0;
+            }else {
+                prevVal = parseInt(prev.current)||0;
+                newVal = parseInt(obj.get('current'))||0;
+            }
+            if(newVal !== prevVal) {
+                var targetChars = [];
+                var allCharacters = findObjs({
+                    _type: 'character',
+                    archived: false
+                }, {caseInsensitive: true});
+                var originChar = getObj('character', obj.get('_characterid'));
+                var originCharName = originChar.get('name');
+                var sheetType = getAttrByName(originChar.id, 'sheet_type');
+                var npcOwner = getAttrByName(originChar.id, 'npc_owner');
+                
+                if((sheetType === 'pc') && originCharName) {
+                    // If PC, add ID of every character owned by this PC to target characters array
+                    _.each(allCharacters, function(obj){
+                        if(getAttrByName(obj.id, 'npc_owner') === originCharName) {targetChars.push(obj.id)}
+                    });
+                }else if ((sheetType === 'npc') && npcOwner) {
+                    // If NPC, add ID of every character with same 'npc_owner' to target characters array
+                    _.each(allCharacters, function(obj) {
+                        if(getAttrByName(obj.id, 'npc_owner') === npcOwner) {targetChars.push(obj.id)}
+                    });
+                    // Add sheets where 'character_name' equals 'npc_owner' to target characters array
+                    _.each(allCharacters, function(obj) {
+                        if(obj.get('name') === npcOwner) {targetChars.push(obj.id)}
+                    });
+                }
+
+                /*log(`sheet_type = \'${sheetType}\', npc_owner = \'${npcOwner}\'`);
+                if(isMax) {
+                    log(`\'${obj.get('name')}\' (max) of character \'${originCharName}\' changed from ${prevVal} to ${newVal}`);
+                }else {
+                    log(`\'${obj.get('name')}\' of character \'${originCharName}\' changed from ${prevVal} to ${newVal}`);
+                }*/
+
+                if(Array.isArray(targetChars) && targetChars.length){
+                    if(isMax){
+                        //log(`!setattr --charid ${targetChars} --tenacity_current||${newVal} --silent --nocreate`);
+                        sendChat('API', `!setattr --charid ${targetChars} --tenacity_current||${newVal} --silent --nocreate`, null, {noarchive:true} );
+                    }else {
+                        //log(`!setattr --charid ${targetChars} --tenacity_current|${newVal} --silent --nocreate`);
+                        sendChat('API', `!setattr --charid ${targetChars} --tenacity_current|${newVal} --silent --nocreate`, null, {noarchive:true} );
+                    }
+                }
+            }
+        }
+    },
+
+    registerEventHandlers = function () {
+        on('change:attribute:current', function(obj, prev){handleAttribute(obj, prev, false)});
+        on('change:attribute:max', function(obj, prev){handleAttribute(obj, prev, true)});
+    };
+    
+    return {
+        CheckInstall: checkInstall,
+        RegisterEventHandlers: registerEventHandlers
+    };
+
+}());
+
+on('ready', () => {
+    'use strict';
+
+    DrD2LinkedTenacity.CheckInstall();
+    DrD2LinkedTenacity.RegisterEventHandlers();
+});

--- a/DrD2LinkedTenacity/DrD2LinkedTenacity.js
+++ b/DrD2LinkedTenacity/DrD2LinkedTenacity.js
@@ -1,0 +1,92 @@
+// Github:   TBD
+// By:       nesuprachy
+// Contact:  https://app.roll20.net/users/11071738/nesuprachy
+//
+// This script tracks changes made to the 'tenacity_current' attribute and propagates them to other sheets linked via the 'npc_owner' attribute.
+// Uses ChatSetAttr mod to change attributes from chat https://github.com/Roll20/roll20-api-scripts/tree/master/ChatSetAttr#readme
+
+var DrD2LinkedTenacity = DrD2LinkedTenacity || (function() {
+    'use strict';
+    
+    const version = '0.1.0';
+    const lastUpdate = '1715082359599';
+        
+    checkInstall = function () {
+        log(`-=> DrD2LinkedTenacity v${version} <=-  [${new Date(lastUpdate*1000)}]`);
+    },
+
+    handleAttribute = function (obj, prev, isMax) {
+        if(obj.get('name') === 'tenacity_current') {
+            var prevVal, newVal = 0;
+            if(isMax){
+                prevVal = parseInt(prev.max)||0;
+                newVal = parseInt(obj.get('max'))||0;
+            }else {
+                prevVal = parseInt(prev.current)||0;
+                newVal = parseInt(obj.get('current'))||0;
+            }
+            if(newVal !== prevVal) {
+                var targetChars = [];
+                var allCharacters = findObjs({
+                    _type: 'character',
+                    archived: false
+                }, {caseInsensitive: true});
+                var originChar = getObj('character', obj.get('_characterid'));
+                var originCharName = originChar.get('name');
+                var sheetType = getAttrByName(originChar.id, 'sheet_type');
+                var npcOwner = getAttrByName(originChar.id, 'npc_owner');
+                
+                if((sheetType === 'pc') && originCharName) {
+                    // If PC, add ID of every character owned by this PC to target characters array
+                    _.each(allCharacters, function(obj){
+                        if(getAttrByName(obj.id, 'npc_owner') === originCharName) {targetChars.push(obj.id)}
+                    });
+                }else if ((sheetType === 'npc') && npcOwner) {
+                    // If NPC, add ID of every character with same 'npc_owner' to target characters array
+                    _.each(allCharacters, function(obj) {
+                        if(getAttrByName(obj.id, 'npc_owner') === npcOwner) {targetChars.push(obj.id)}
+                    });
+                    // Add sheets where 'character_name' equals 'npc_owner' to target characters array
+                    _.each(allCharacters, function(obj) {
+                        if(obj.get('name') === npcOwner) {targetChars.push(obj.id)}
+                    });
+                }
+
+                /*log(`sheet_type = \'${sheetType}\', npc_owner = \'${npcOwner}\'`);
+                if(isMax) {
+                    log(`\'${obj.get('name')}\' (max) of character \'${originCharName}\' changed from ${prevVal} to ${newVal}`);
+                }else {
+                    log(`\'${obj.get('name')}\' of character \'${originCharName}\' changed from ${prevVal} to ${newVal}`);
+                }*/
+
+                if(Array.isArray(targetChars) && targetChars.length){
+                    if(isMax){
+                        //log(`!setattr --charid ${targetChars} --tenacity_current||${newVal} --silent --nocreate`);
+                        sendChat('API', `!setattr --charid ${targetChars} --tenacity_current||${newVal} --silent --nocreate`, null, {noarchive:true} );
+                    }else {
+                        //log(`!setattr --charid ${targetChars} --tenacity_current|${newVal} --silent --nocreate`);
+                        sendChat('API', `!setattr --charid ${targetChars} --tenacity_current|${newVal} --silent --nocreate`, null, {noarchive:true} );
+                    }
+                }
+            }
+        }
+    },
+
+    registerEventHandlers = function () {
+        on('change:attribute:current', function(obj, prev){handleAttribute(obj, prev, false)});
+        on('change:attribute:max', function(obj, prev){handleAttribute(obj, prev, true)});
+    };
+    
+    return {
+        CheckInstall: checkInstall,
+        RegisterEventHandlers: registerEventHandlers
+    };
+
+}());
+
+on('ready', () => {
+    'use strict';
+
+    DrD2LinkedTenacity.CheckInstall();
+    DrD2LinkedTenacity.RegisterEventHandlers();
+});

--- a/DrD2LinkedTenacity/script.json
+++ b/DrD2LinkedTenacity/script.json
@@ -1,0 +1,18 @@
+{
+    "name": "DrD2LinkedTenacity",
+    "script": "DrD2LinkedTenacity.js",
+    "version": "0.1.0",
+    "previousversions": [],
+    "description": "Designed for use only with the Draci Doupe II sheet.\n\nThis script tracks changes made to the 'tenacity_current' attribute and propagates them to other sheets linked via the 'npc_owner' attribute.",
+    "authors": "nesuprachy",
+    "roll20userid": "11071738",
+    "useroptions": [],
+    "dependencies": ["ChatSetAttr"],
+    "modifies": {
+        "attribute.current": "read,write",
+        "attribute.max": "read,write",
+        "attribute.characterid": "read",
+        "character.name": "read"
+    },
+    "conflicts": []
+}


### PR DESCRIPTION
I would like to publish my script to the official Roll20 script respository. However, it is only designed for use with the Draci Doupe II sheet since it interacts with specific attributes. I wonder if it can be published under the "System Toolbox" category?

Please let me know if it is possible and also whether or not my script meets the requirements for publishing.

### What it does
The script allows for changes made to an NPC's `tenacity_current` attribute to be propagated to a PC character's sheet if the PC has been designated as the NPC's owner, and vice versa. Think about it as heroes having companions where "tenacity" indicates how long the companion can last in a conflict. _Tenacity_ is my loose translation of the word _sudba_.
Also works for groups of enemy NPC's that should share the "tenacity" property.

GIF to demonstrate its function:
![Recording 2024-05-07 at 13 59 42](https://github.com/Roll20/roll20-api-scripts/assets/64099419/d4c8c013-4e0e-4c3b-beb1-347deae92e15)
