### PR TITLE
New API to Show only Images to Players

### DIFF
--- a/HandoutImageDisplay/1.1.0/HandoutImageDisplay.js
+++ b/HandoutImageDisplay/1.1.0/HandoutImageDisplay.js
@@ -1,0 +1,245 @@
+/* HandoutImageDisplay v1.1.0 — Roll20 Mod script
+ * Reuses one player-safe handout to display another handout's main image.
+ * Commands: !showimage|Handout Name, !showimage --share,
+ *           !showimage --hide, !showimage --help
+ */
+var HandoutImageDisplay = HandoutImageDisplay || (function () {
+    'use strict';
+
+    var SCRIPT = 'HandoutImageDisplay';
+    var VERSION = '1.1.0';
+    var DISPLAY_NAME = 'Image Display';
+    var FALLBACK_NAME = 'Image Display (HandoutImageDisplay)';
+    var MARKER = '[HandoutImageDisplay]';
+    var MACRO_NAME = 'Handout Image Display';
+    var MACRO_FALLBACK_NAME = 'Handout Image Display (API)';
+    var MACRO_ACTION = '?{Image Display|Show Image,!showimage&#124;?{Handout Name&#125;|Hide Image,!showimage --hide}';
+
+    function config() {
+        state.HandoutImageDisplay = state.HandoutImageDisplay || {
+            schemaVersion: 1,
+            displayHandoutId: '',
+            macroIds: {}
+        };
+        state.HandoutImageDisplay.macroIds = state.HandoutImageDisplay.macroIds || {};
+        return state.HandoutImageDisplay;
+    }
+
+    function esc(value) {
+        return String(value == null ? '' : value)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function decodeEntities(value) {
+        return String(value || '').replace(/&amp;/gi, '&')
+            .replace(/&quot;/gi, '"').replace(/&#39;/gi, "'")
+            .replace(/&lt;/gi, '<').replace(/&gt;/gi, '>');
+    }
+
+    function decodeEditor(value) {
+        try { return decodeURIComponent(String(value || '')); }
+        catch (error) { return String(value || ''); }
+    }
+
+    function whisper(who, html) {
+        sendChat(SCRIPT,
+            '/w "' + String(who || 'gm').replace(/"/g, '') + '" ' + html,
+            null, { noarchive: true });
+    }
+
+    function panel(title, body) {
+        return '<div style="border:1px solid #555;background:#fff;padding:8px;border-radius:4px;">' +
+            '<div style="font-weight:bold;margin-bottom:6px;">' + esc(title) + '</div>' +
+            body + '</div>';
+    }
+
+    function journalUrl(handout) {
+        return 'https://journal.roll20.net/handout/' + handout.id;
+    }
+
+    function resolveHandout(name) {
+        var wanted = String(name || '').trim().toLowerCase();
+        var matches;
+        if (!wanted) { return { error: 'Enter a handout name.' }; }
+        matches = findObjs({ _type: 'handout' }).filter(function (handout) {
+            return String(handout.get('name') || '').trim().toLowerCase() === wanted;
+        });
+        if (matches.length === 1) { return { handout: matches[0] }; }
+        return { error: matches.length ?
+            'More than one handout has that name. Rename one and try again.' :
+            'No handout with that name was found.' };
+    }
+
+    function displayHandout(createIfMissing) {
+        var settings = config();
+        var display = settings.displayHandoutId && getObj('handout', settings.displayHandoutId);
+        var named;
+        if (display) { return display; }
+
+        named = findObjs({ _type: 'handout', name: DISPLAY_NAME });
+        if (!createIfMissing) { return null; }
+
+        display = createObj('handout', {
+            name: named.length ? FALLBACK_NAME : DISPLAY_NAME,
+            inplayerjournals: '',
+            archived: false
+        });
+        settings.displayHandoutId = display.id;
+        return display;
+    }
+
+    function adopt(who) {
+        var matches = findObjs({ _type: 'handout', name: DISPLAY_NAME });
+        if (matches.length !== 1) {
+            whisper(who, panel('Cannot adopt Image Display', '<div>' +
+                (matches.length ? 'More than one handout has that exact name.' :
+                    'No handout named <b>Image Display</b> was found.') + '</div>'));
+            return;
+        }
+        config().displayHandoutId = matches[0].id;
+        whisper(who, panel('Image Display adopted',
+            '<div>The existing handout will now be reused by this script.</div>'));
+    }
+
+    function setupMacro(playerId, who) {
+        var settings = config();
+        var macro = settings.macroIds[playerId] && getObj('macro', settings.macroIds[playerId]);
+        var named;
+        var macroName = MACRO_NAME;
+        var created = false;
+
+        if (!macro) {
+            named = findObjs({ _type: 'macro', _playerid: playerId, name: MACRO_NAME });
+            macro = named.filter(function (candidate) {
+                return String(candidate.get('action') || '').indexOf('!showimage') !== -1;
+            })[0];
+            if (!macro) {
+                if (named.length) { macroName = MACRO_FALLBACK_NAME; }
+                macro = createObj('macro', {
+                    _playerid: playerId,
+                    name: macroName,
+                    action: MACRO_ACTION,
+                    visibleto: '',
+                    istokenaction: false
+                });
+                created = true;
+            }
+            settings.macroIds[playerId] = macro.id;
+        }
+
+        if (macro.get('action') !== MACRO_ACTION || macro.get('istokenaction')) {
+            macro.set({ action: MACRO_ACTION, istokenaction: false });
+        }
+        whisper(who, panel(created ? 'Display macro created' : 'Display macro updated',
+            '<div><b>' + esc(macro.get('name')) + '</b> is ready in Collections.</div>' +
+            '<div style="margin-top:5px;">Tick <b>In Bar</b> in Roll20 if you want it on your Quick Bar.</div>'));
+    }
+
+    function imageFromNotes(notes) {
+        var match = decodeEditor(notes).match(/<img\b[^>]*\bsrc=(['"])([^'"]+)\1/i);
+        return match ? decodeEntities(match[2]) : '';
+    }
+
+    function show(source, imageUrl, who) {
+        var display;
+        if (!imageUrl) {
+            whisper(who, panel('No image found', '<div><b>' + esc(source.get('name')) +
+                '</b> has no main image or image in its notes.</div>'));
+            return;
+        }
+        display = displayHandout(true);
+        if (source.id === display.id) {
+            whisper(who, panel('Cannot display itself',
+                '<div>Choose a different source handout.</div>'));
+            return;
+        }
+        display.set({
+            avatar: imageUrl,
+            notes: '',
+            gmnotes: MARKER + '\nCurrently displaying: ' + source.get('name'),
+            inplayerjournals: 'all',
+            archived: false
+        });
+        whisper(who, panel('Image prepared: ' + source.get('name'),
+            '<div style="margin-bottom:7px;">The reusable handout contains only this image.</div>' +
+            '<a style="background:#356aa0;color:#fff;padding:5px 8px;text-decoration:none;border-radius:3px;margin-right:5px;" href="' +
+            journalUrl(display) + '">Open Image Display</a>' +
+            '<a style="background:#4b8b3b;color:#fff;padding:5px 8px;text-decoration:none;border-radius:3px;" href="!showimage --share">Send Link to Players</a>'));
+    }
+
+    function prepare(name, who) {
+        var result = resolveHandout(name);
+        var source;
+        var avatar;
+        if (result.error) {
+            whisper(who, panel('Handout not resolved', '<div>' + esc(result.error) + '</div>'));
+            return;
+        }
+        source = result.handout;
+        avatar = decodeEntities(String(source.get('avatar') || '').trim());
+        if (avatar) { show(source, avatar, who); return; }
+        source.get('notes', function (notes) {
+            show(source, imageFromNotes(notes), who);
+        });
+    }
+
+    function share(who) {
+        var display = displayHandout(false);
+        if (!display || !display.get('avatar')) {
+            whisper(who, panel('Nothing prepared',
+                '<div>Use <code>!showimage|Handout Name</code> first.</div>'));
+            return;
+        }
+        if (display.get('inplayerjournals') !== 'all') {
+            display.set('inplayerjournals', 'all');
+        }
+        sendChat(SCRIPT, '<div style="text-align:center;"><a style="background:#356aa0;color:#fff;padding:7px 12px;text-decoration:none;border-radius:4px;" href="' +
+            journalUrl(display) + '">View Image</a></div>');
+    }
+
+    function hide(who) {
+        var display = displayHandout(false);
+        if (display && display.get('inplayerjournals')) {
+            display.set('inplayerjournals', '');
+        }
+        whisper(who, panel('Image Display hidden',
+            '<div>It has been removed from player journals.</div>'));
+    }
+
+    function help(who) {
+        whisper(who, panel(SCRIPT + ' ' + VERSION,
+            '<div><code>!showimage|Handout Name</code> — prepare the image.</div>' +
+            '<div><code>!showimage --share</code> — post a player link.</div>' +
+            '<div><code>!showimage --hide</code> — hide the display handout.</div>' +
+            '<div><code>!showimage --adopt</code> — adopt a v1.0 Image Display handout.</div>' +
+            '<div><code>!showimage --setup</code> — create or repair your Collections macro.</div>'));
+    }
+
+    function input(msg) {
+        var command;
+        if (msg.type !== 'api' || !/^!showimage(?:\s|\||$)/i.test(msg.content)) { return; }
+        if (!playerIsGM(msg.playerid)) {
+            whisper(msg.who, panel(SCRIPT, '<div>GM access is required.</div>'));
+            return;
+        }
+        command = msg.content.replace(/^!showimage\s*/i, '').trim();
+        if (/^--share$/i.test(command)) { share(msg.who); }
+        else if (/^--hide$/i.test(command)) { hide(msg.who); }
+        else if (/^--adopt$/i.test(command)) { adopt(msg.who); }
+        else if (/^--setup$/i.test(command)) { setupMacro(msg.playerid, msg.who); }
+        else if (/^--help$/i.test(command) || !command) { help(msg.who); }
+        else if (command.charAt(0) === '|') { prepare(command.slice(1).trim(), msg.who); }
+        else { whisper(msg.who, panel('Invalid command',
+            '<div>Use <code>!showimage --help</code>.</div>')); }
+    }
+
+    function ready() {
+        config();
+        on('chat:message', input);
+        log(SCRIPT + ' v' + VERSION + ' ready.');
+    }
+    return { ready: ready };
+}());
+on('ready', HandoutImageDisplay.ready);

--- a/HandoutImageDisplay/1.1.0/README.md
+++ b/HandoutImageDisplay/1.1.0/README.md
@@ -1,0 +1,107 @@
+# HandoutImageDisplay
+
+HandoutImageDisplay restores a practical image-only reveal workflow for Roll20 handouts. It copies the main image from a source handout into one reusable, player-safe **Image Display** handout without exposing the source handout's notes or GM notes.
+
+The script reuses the same display handout for every image. It does not create a new handout for each reveal.
+
+## Requirements
+
+- A Roll20 game created by a Pro subscriber.
+- No script dependencies.
+- Commands are restricted to the GM.
+
+## Installation
+
+### Manual installation
+
+1. Open the game's **Mod (API) Scripts** page.
+2. Create a new script named `HandoutImageDisplay`.
+3. Paste in `HandoutImageDisplay.js`.
+4. Save the script and wait for the Mod sandbox to restart.
+
+The reusable display handout is created automatically the first time an image is prepared.
+
+Run the setup command once as each GM who wants the supplied Collections macro:
+
+```text
+!showimage --setup
+```
+
+This creates or repairs a macro named **Handout Image Display** for that GM. Roll20's **In Bar** setting is a personal interface choice, so tick it in Collections if the macro should appear on the Quick Bar.
+
+## Commands
+
+### Prepare an image
+
+```text
+!showimage|Handout Name
+```
+
+The name match is case-insensitive but must otherwise be exact. The script first uses the handout's main image. If no main image exists, it uses the first image embedded in the handout notes.
+
+The source handout remains unchanged. The reusable display handout is made visible in all player journals and contains only the selected image.
+
+### Share a clickable link
+
+```text
+!showimage --share
+```
+
+Posts a **View Image** link in public chat. Players can click it to open the reusable display handout.
+
+### Hide the display
+
+```text
+!showimage --hide
+```
+
+Removes the reusable display handout from player journals. It does not delete the handout or its current image.
+
+### Help
+
+```text
+!showimage --help
+```
+
+### Create or repair the Collections macro
+
+```text
+!showimage --setup
+```
+
+The command affects only the GM who runs it and will not overwrite an unrelated macro with the same name.
+
+## Collections macro created by setup
+
+```text
+?{Image Display|Show Image,!showimage&#124;?{Handout Name&#125;|Hide Image,!showimage --hide}
+```
+
+This provides a single macro-bar menu with **Show Image** and **Hide Image** options.
+
+## Safety behaviour
+
+- Only GMs can use the commands.
+- The script stores the ID of the handout it owns.
+- It will not overwrite an unrelated handout merely because it is named `Image Display`.
+- If that name is already in use, the script creates `Image Display (HandoutImageDisplay)` instead.
+- A GM upgrading from version 1.0 can explicitly adopt the old display handout with `!showimage --adopt`.
+- Duplicate source-handout names are reported rather than guessed.
+
+### Upgrading from version 1.0
+
+If version 1.0 already created a handout named **Image Display**, run this once after installing version 1.1:
+
+```text
+!showimage --adopt
+```
+
+The command refuses to guess if no exact match exists or several handouts share that name.
+
+## Roll20 limitation
+
+Mod scripts cannot invoke Roll20's client-side image lightbox or simulate **Shift+Z**. For the closest replacement to the former image-only reveal, prepare the image, open **Image Display**, and use Roll20's **Show to Players** control. Alternatively, use `!showimage --share` to post a player-accessible link.
+
+## Licence
+
+Released under the MIT Licence.

--- a/HandoutImageDisplay/LICENSE
+++ b/HandoutImageDisplay/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kingkiller
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/HandoutImageDisplay/script.json
+++ b/HandoutImageDisplay/script.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://github.com/Roll20/roll20-api-scripts/master/_Example%20Script%20-%20Check%20for%20formatting%20details/script.schema.json",
+  "name": "HandoutImageDisplay",
+  "script": "HandoutImageDisplay.js",
+  "version": "1.1.0",
+  "previousversions": [],
+  "description": "Copies the main image from any named handout into one reusable, player-safe Image Display handout without revealing the source handout's notes or GM notes. GM commands: !showimage|Handout Name prepares an image; !showimage --share posts a player-accessible link; !showimage --hide removes the display from player journals; !showimage --setup creates or repairs the combined Collections macro for the current GM; !showimage --adopt safely adopts a v1.0 display handout; !showimage --help displays help. No dependencies are required.",
+  "authors": "Kingkiller",
+  "roll20userid": "2978722",
+  "dependencies": [],
+  "modifies": {
+    "state.HandoutImageDisplay": "read,write",
+    "handout.name": "read",
+    "handout.avatar": "read,write",
+    "handout.notes": "read,write",
+    "handout.gmnotes": "read,write",
+    "handout.inplayerjournals": "read,write",
+    "handout.archived": "read,write",
+    "macro._playerid": "read,write",
+    "macro.name": "read,write",
+    "macro.action": "read,write",
+    "macro.visibleto": "read,write",
+    "macro.istokenaction": "read,write"
+  },
+  "conflicts": []
+}


### PR DESCRIPTION
restores a practical image-only reveal workflow for Roll20 handouts. It copies The main image from a source handout into one reusable, player-safe **Image Display** handout without exposing the source handout's notes or GM notes.